### PR TITLE
Check if bikes allowed on trip

### DIFF
--- a/core/src/main/java/com/graphhopper/config/Profile.java
+++ b/core/src/main/java/com/graphhopper/config/Profile.java
@@ -84,6 +84,10 @@ public class Profile {
         return turnCosts;
     }
 
+    public boolean isBike() {
+        return vehicle.contains("bike");
+    }
+
     public Profile setTurnCosts(boolean turnCosts) {
         this.turnCosts = turnCosts;
         return this;

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
@@ -112,7 +112,7 @@ public class GraphHopperGtfs extends GraphHopper {
         QueryGraph queryGraph = QueryGraph.create(graphHopperStorage, Collections.emptyList());
         String transferProfileName = ghConfig.getString("pt.transfer_profile", "foot");
         Weighting transferWeighting = createWeighting(getProfile(transferProfileName), new PMap());
-        final GraphExplorer graphExplorer = new GraphExplorer(queryGraph, ptGraph, transferWeighting, getGtfsStorage(), RealtimeFeed.empty(), true, true, false, 5.0, false, 0);
+        final GraphExplorer graphExplorer = new GraphExplorer(queryGraph, ptGraph, transferWeighting, getGtfsStorage(), RealtimeFeed.empty(), true, true, false, false, false, 0);
         getGtfsStorage().getStationNodes().values().stream().distinct().map(n -> {
             int streetNode = Optional.ofNullable(gtfsStorage.getPtToStreet().get(n)).orElse(-1);
             return new Label.NodeId(streetNode, n);

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GtfsReader.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GtfsReader.java
@@ -286,7 +286,8 @@ class GtfsReader {
             int arrivalTimelineNode = arrivalTimeline.computeIfAbsent((stopTime.arrival_time + time) % (24 * 60 * 60), t -> out.createNode());
             departureNode = out.createNode();
             int dayShift = stopTime.departure_time / (24 * 60 * 60);
-            GtfsStorage.Validity validOn = new GtfsStorage.Validity(getValidOn(trip.validOnDay, dayShift), zoneId, startDate);
+            boolean bikesAllowed = !(trip.trip.bikes_allowed == 2);
+            GtfsStorage.Validity validOn = new GtfsStorage.Validity(getValidOn(trip.validOnDay, dayShift), zoneId, startDate, bikesAllowed);
             out.createEdge(departureTimelineNode, departureNode, new PtEdgeAttributes(GtfsStorage.EdgeType.BOARD, 0, validOn, -1, null, 1, stopTime.stop_sequence, tripDescriptor, null));
             out.createEdge(arrivalNode, arrivalTimelineNode, new PtEdgeAttributes(GtfsStorage.EdgeType.ALIGHT, 0, validOn, -1, null, 0, stopTime.stop_sequence, tripDescriptor, null));
             out.createEdge(arrivalNode, departureNode, new PtEdgeAttributes(GtfsStorage.EdgeType.DWELL, stopTime.departure_time - stopTime.arrival_time, null, -1, null, 0, -1, null, null));
@@ -404,7 +405,8 @@ class GtfsReader {
         int departureTimelineNode = departureTimelineNodes.computeIfAbsent(departureTime % (24 * 60 * 60), t -> ptGraph.createNode());
 
         int dayShift = departureTime / (24 * 60 * 60);
-        GtfsStorage.Validity validOn = new GtfsStorage.Validity(getValidOn(validOnDay, dayShift), zoneId, startDate);
+        boolean bikesAllowed = !(trip.bikes_allowed == 2);
+        GtfsStorage.Validity validOn = new GtfsStorage.Validity(getValidOn(validOnDay, dayShift), zoneId, startDate, bikesAllowed);
         return out.createEdge(departureTimelineNode, departureNode, new PtEdgeAttributes(GtfsStorage.EdgeType.BOARD, 0, validOn, -1, null, 1, stopSequence, tripDescriptor, null));
     }
 
@@ -443,7 +445,7 @@ class GtfsReader {
                 BitSet blockTransferValidity = new BitSet(validOn.validity.size());
                 blockTransferValidity.or(validOn.validity);
                 blockTransferValidity.and(accumulatorValidity);
-                GtfsStorage.Validity blockTransferValidOn = new GtfsStorage.Validity(blockTransferValidity, zoneId, startDate);
+                GtfsStorage.Validity blockTransferValidOn = new GtfsStorage.Validity(blockTransferValidity, zoneId, startDate, validOn.bikesAllowed);
                 int node = ptGraph.createNode();
                 out.createEdge(lastTrip.arrivalNode, node, new PtEdgeAttributes(GtfsStorage.EdgeType.TRANSFER, dwellTime, null, -1, null, 0, -1, null, platform));
                 out.createEdge(node, departureNode, new PtEdgeAttributes(GtfsStorage.EdgeType.BOARD, 0, blockTransferValidOn, -1, null, 0, stopTime.stop_sequence, tripDescriptor, null));

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GtfsStorage.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GtfsStorage.java
@@ -61,18 +61,20 @@ public class GtfsStorage {
 		final BitSet validity;
 		final ZoneId zoneId;
 		final LocalDate start;
+		final boolean bikesAllowed;
 
-		public Validity(BitSet validity, ZoneId zoneId, LocalDate start) {
+		public Validity(BitSet validity, ZoneId zoneId, LocalDate start, boolean bikesAllowed) {
 			this.validity = validity;
 			this.zoneId = zoneId;
 			this.start = start;
+			this.bikesAllowed = bikesAllowed;
 		}
 
 		@Override
 		public boolean equals(Object other) {
 			if (! (other instanceof Validity)) return false;
 			Validity v = (Validity) other;
-			return validity.equals(v.validity) && zoneId.equals(v.zoneId) && start.equals(v.start);
+			return validity.equals(v.validity) && zoneId.equals(v.zoneId) && start.equals(v.start) && bikesAllowed == v.bikesAllowed;
 		}
 
 		@Override

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/PtRouterFreeWalkImpl.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/PtRouterFreeWalkImpl.java
@@ -201,7 +201,7 @@ public final class PtRouterFreeWalkImpl implements PtRouter {
         private List<List<Label.Transition>> findPaths(Label.NodeId startNode, Label.NodeId destNode) {
             StopWatch stopWatch = new StopWatch().start();
 
-            GraphExplorer graphExplorer = new GraphExplorer(queryGraph, ptGraph, accessEgressWeighting, gtfsStorage, realtimeFeed, arriveBy, false, false, walkSpeedKmH, false, blockedRouteTypes);
+            GraphExplorer graphExplorer = new GraphExplorer(queryGraph, ptGraph, accessEgressWeighting, gtfsStorage, realtimeFeed, arriveBy, false, false, connectingProfile.isBike(), false, blockedRouteTypes);
             List<Label> discoveredSolutions = new ArrayList<>();
             router = new MultiCriteriaLabelSetting(graphExplorer, arriveBy, !ignoreTransfers, profileQuery, maxProfileDuration, discoveredSolutions);
             router.setBetaTransfers(betaTransfers);

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/PtRouterImpl.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/PtRouterImpl.java
@@ -200,7 +200,7 @@ public final class PtRouterImpl implements PtRouter {
         private List<List<Label.Transition>> findPaths(Label.NodeId startNode, Label.NodeId destNode) {
             StopWatch stopWatch = new StopWatch().start();
             boolean isEgress = !arriveBy;
-            final GraphExplorer accessEgressGraphExplorer = new GraphExplorer(queryGraph, ptGraph, connectingWeighting, gtfsStorage, realtimeFeed, isEgress, true, false, walkSpeedKmH, false, blockedRouteTypes);
+            final GraphExplorer accessEgressGraphExplorer = new GraphExplorer(queryGraph, ptGraph, connectingWeighting, gtfsStorage, realtimeFeed, isEgress, true, false, connectingProfile.isBike(), false, blockedRouteTypes);
             GtfsStorage.EdgeType edgeType = isEgress ? GtfsStorage.EdgeType.EXIT_PT : GtfsStorage.EdgeType.ENTER_PT;
             MultiCriteriaLabelSetting stationRouter = new MultiCriteriaLabelSetting(accessEgressGraphExplorer, isEgress, false, false, maxProfileDuration, new ArrayList<>());
             stationRouter.setBetaStreetTime(betaStreetTime);
@@ -221,7 +221,7 @@ public final class PtRouterImpl implements PtRouter {
                 reverseSettledSet.put(stationLabel.node, stationLabel);
             }
 
-            GraphExplorer graphExplorer = new GraphExplorer(queryGraph, ptGraph, connectingWeighting, gtfsStorage, realtimeFeed, arriveBy, false, true, walkSpeedKmH, false, blockedRouteTypes);
+            GraphExplorer graphExplorer = new GraphExplorer(queryGraph, ptGraph, connectingWeighting, gtfsStorage, realtimeFeed, arriveBy, false, true, connectingProfile.isBike(), false, blockedRouteTypes);
             List<Label> discoveredSolutions = new ArrayList<>();
             router = new MultiCriteriaLabelSetting(graphExplorer, arriveBy, !ignoreTransfers, profileQuery, maxProfileDuration, discoveredSolutions);
             router.setBetaTransfers(betaTransfers);

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
@@ -367,6 +367,7 @@ class TripFromLabel {
                             Optional.ofNullable(trip).map(t -> t.trip_headsign).orElse("extra"),
                             route.route_color,
                             route.route_short_name,
+                            trip.bikes_allowed,
                             agency.agency_name,
                             stops,
                             partition.stream().mapToDouble(t -> t.edge.getDistance()).sum(),

--- a/web-api/src/main/java/com/graphhopper/Trip.java
+++ b/web-api/src/main/java/com/graphhopper/Trip.java
@@ -101,13 +101,14 @@ public class Trip {
         public final String trip_headsign;
         public final String route_color;
         public final String route_name;
+        public final int bikes_allowed;
 
         public final long travelTime;
         public final List<Stop> stops;
         public final String trip_id;
         public final String route_id;
 
-        public PtLeg(String feedId, boolean isInSameVehicleAsPrevious, String tripId, String routeId, String headsign, String color, String routeName, String agencyName, List<Stop> stops, double distance, long travelTime, Geometry geometry) {
+        public PtLeg(String feedId, boolean isInSameVehicleAsPrevious, String tripId, String routeId, String headsign, String color, String routeName, int bikesAllowed, String agencyName, List<Stop> stops, double distance, long travelTime, Geometry geometry) {
             super("pt", stops.get(0).stop_name, geometry, distance);
             this.feed_id = feedId;
             this.agency_name = agencyName;
@@ -116,6 +117,7 @@ public class Trip {
             this.route_id = routeId;
             this.route_color = color;
             this.route_name = routeName;
+            this.bikes_allowed = bikesAllowed;
             this.trip_headsign = headsign;
             this.travelTime = travelTime;
             this.stops = stops;


### PR DESCRIPTION
Fixes #16 

Adds checks for `bikes_allowed` from trips.txt. unfortunately GTFS is bad and does not match reality, so i added a `ignoreBikesAllowed` flag in `GraphExplorer` to completely ignore that. but it's there if we need it