### PR TITLE
Expose path details on route-pt, and add cycleway tag to available details

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ev/Cycleway.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Cycleway.java
@@ -1,5 +1,49 @@
 package com.graphhopper.routing.ev;
 
-public class Cycleway {
+public enum Cycleway {
+
+  /**
+   * This enum defines the cycling infrastructure that is an inherent part of the
+   * road.
+   * It is heavily influenced from the cycleway tag in OSM.
+   * All edges that do not fit get OTHER as value.
+   */
+  OTHER("other"),
+  ASL("asl"),
+  CROSSING("crossing"),
+  LANE("lane"), OPPOSITE_LANE("opposite_lane"),
+  NO("no"),
+  OPPOSITE("opposite"),
+  SEPARATE("separate"),
+  SHARE_BUSWAY("share_busway"), OPPOSITE_SHARE_BUSWAY("opposite_share_busway"),
+  SHARED_LANE("shared_lane"),
+  SHARED("shared"),
+  SHOULDER("shoulder"),
+  TRACK("track"), OPPOSITE_TRACK("opposite_track");
+
   public static final String KEY = "cycleway";
+
+  private final String name;
+
+  Cycleway(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  public static Cycleway find(String name) {
+    if (name == null || name.isEmpty())
+      return OTHER;
+
+    for (Cycleway cycleway : values()) {
+      if (cycleway.name().equalsIgnoreCase(name)) {
+        return cycleway;
+      }
+    }
+
+    return OTHER;
+  }
 }

--- a/core/src/main/java/com/graphhopper/routing/ev/Cycleway.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Cycleway.java
@@ -1,0 +1,5 @@
+package com.graphhopper.routing.ev;
+
+public class Cycleway {
+  public static final String KEY = "cycleway";
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
@@ -70,6 +70,8 @@ public class DefaultEncodedValueFactory implements EncodedValueFactory {
             enc = new EnumEncodedValue<>(HazmatTunnel.KEY, HazmatTunnel.class);
         } else if (HazmatWater.KEY.equals(name)) {
             enc = new EnumEncodedValue<>(HazmatWater.KEY, HazmatWater.class);
+        } else if (Cycleway.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(Cycleway.KEY, Cycleway.class);
         } else if (name.endsWith(Subnetwork.key(""))) {
             enc = new SimpleBooleanEncodedValue(name);
         } else {

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -325,6 +325,8 @@ public class EncodingManager implements EncodedValueLookup {
                         _addEdgeTagParser(new OSMGetOffBikeParser(), false);
                     if (!em.hasEncodedValue(Smoothness.KEY))
                         _addEdgeTagParser(new OSMSmoothnessParser(), false);
+                    if (!em.hasEncodedValue(Cycleway.KEY))
+                        _addEdgeTagParser(new OSMCyclewayParser(), false);
                 } else if (encoder instanceof FootFlagEncoder) {
                     if (!em.hasEncodedValue(RouteNetwork.key("foot")))
                         _addRelationTagParser(new OSMFootNetworkTagParser());

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -75,6 +75,8 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new OSMHorseRatingParser();
         else if (name.equals(Country.KEY))
             return new CountryParser();
+        else if (name.equals(Cycleway.KEY))
+            return new OSMCyclewayParser();
 
         throw new IllegalArgumentException("DefaultTagParserFactory cannot find: " + name);
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
@@ -1,0 +1,39 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.Cycleway;
+import com.graphhopper.storage.IntsRef;
+
+import java.util.List;
+
+public class OSMCyclewayParser implements TagParser {
+  
+  private final EnumEncodedValue<Cycleway> cyclewayEnc;
+
+  public OSMCyclewayParser() {
+      this(new EnumEncodedValue<>(Cycleway.KEY, Cycleway.class));
+  }
+
+  public OSMCyclewayParser(EnumEncodedValue<Cycleway> cyclewayEnc) {
+      this.cyclewayEnc = cyclewayEnc;
+  }
+
+  @Override
+  public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
+      list.add(cyclewayEnc);
+  }
+
+  @Override
+  public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
+      String cyclewayTag = readerWay.getTag("cycleway");
+      if (cyclewayTag == null)
+        return edgeFlags;
+      Cycleway cycleway = Cycleway.find(cyclewayTag);
+
+      cyclewayEnc.setEnum(false, edgeFlags, cycleway);
+      return edgeFlags;
+  }
+}

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
@@ -76,7 +76,7 @@ public class PathDetailsBuilderFactory {
 
         for (String key : Arrays.asList(RoadClass.KEY, RoadEnvironment.KEY, Surface.KEY, Smoothness.KEY, RoadAccess.KEY,
                 BikeNetwork.KEY, FootNetwork.KEY, Toll.KEY, TrackType.KEY, Hazmat.KEY, HazmatTunnel.KEY,
-                HazmatWater.KEY, Country.KEY)) {
+                HazmatWater.KEY, Country.KEY, Cycleway.KEY)) {
             if (requestedPathDetails.contains(key) && evl.hasEncodedValue(key))
                 builders.add(new EnumDetails<>(key, evl.getEnumEncodedValue(key, Enum.class)));
         }

--- a/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
@@ -65,7 +65,8 @@ public class PtRouteResource {
                             @QueryParam("pt.limit_trip_time") DurationParam limitTripTime,
                             @QueryParam("pt.limit_street_time") DurationParam limitStreetTime,
                             @QueryParam("pt.connecting_profile") String connectingProfile,
-                            @QueryParam("elevation") @DefaultValue("false") boolean enableElevation) {
+                            @QueryParam("elevation") @DefaultValue("false") boolean enableElevation,
+                            @QueryParam("details") List<String> pathDetails) {
         StopWatch stopWatch = new StopWatch().start();
         List<GHLocation> points = requestPoints.stream().map(AbstractParam::get).collect(toList());
         Instant departureTime = departureTimeParam.get().toInstant();
@@ -81,6 +82,7 @@ public class PtRouteResource {
         Optional.ofNullable(limitStreetTime.get()).ifPresent(request::setLimitStreetTime);
         Optional.ofNullable(connectingProfile).ifPresent(request::setConnectingProfile);
         Optional.ofNullable(enableElevation).ifPresent(request::setEnableElevation);
+        Optional.ofNullable(pathDetails).ifPresent(request::setPathDetails);
 
         GHResponse route = ptRouter.route(request);
         return ResponsePathSerializer.jsonObject(route, true, true, enableElevation, false, stopWatch.stop().getMillis());


### PR DESCRIPTION
This should allow someone to make a query like:
```
/route-pt?point=50.451821,9.615784&point=50.309515,9.447556&details=cycleway&details=street_name...
```

The returned information would be:
```
{ ... usual JSON ...
  "points": { "coordinates":[[6.72911,49.106228,289],[6.729268,49.106145,285.4],[6.729459,49.105949,285.4],...]},
  "details":{
   "cycleway":"track",
   "street_name":[[0,2,"Frankfurter Straße"],[2,6,"Zollweg, L 3206"],...]
  }
}
```
(data made up from [here](https://discuss.graphhopper.com/t/new-routing-api-feature-path-details-and-support-for-avoiding-motorway-ferry-toll/2539))