### PR TITLE
Add more cycleway values that are used commonly

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ev/Cycleway.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Cycleway.java
@@ -46,7 +46,6 @@ public enum Cycleway {
       }
     }
 
-    System.out.println("Cycleway asked to find name: " + name);
     return OTHER;
   }
 }

--- a/core/src/main/java/com/graphhopper/routing/ev/Cycleway.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Cycleway.java
@@ -12,14 +12,16 @@ public enum Cycleway {
   ASL("asl"),
   CROSSING("crossing"),
   LANE("lane"), OPPOSITE_LANE("opposite_lane"),
-  NO("no"),
+  NO("no"),YES("yes"),
   OPPOSITE("opposite"),
   SEPARATE("separate"),
   SHARE_BUSWAY("share_busway"), OPPOSITE_SHARE_BUSWAY("opposite_share_busway"),
   SHARED_LANE("shared_lane"),
   SHARED("shared"),
   SHOULDER("shoulder"),
-  TRACK("track"), OPPOSITE_TRACK("opposite_track");
+  TRACK("track"), OPPOSITE_TRACK("opposite_track"),
+  RIGHT("right"), LEFT("left"), BOTH("both"),
+  SIDEPATH("sidepath");
 
   public static final String KEY = "cycleway";
 
@@ -44,6 +46,7 @@ public enum Cycleway {
       }
     }
 
+    System.out.println("Cycleway asked to find name: " + name);
     return OTHER;
   }
 }


### PR DESCRIPTION
I ran through all the bay area network and found some additional cycleway values that appear to be valid based on the wiki.  Hence this PR to add them.

Below are the other values I found in the bay area network that I believe are tagging mistakes based on reading the wiki, and a suggested change by me. We can make these changes ourselves potentially; it would be nice to improve the data directly. With some additional work I can make a list of all these incorrectly tagged ways.
- cyclestreet ==> cyclestreet=yes
- sidewalk ==> track
- designated ==> bicycle=designated or highway=cycleway
- "shouder" ==> shoulder
- none ==> no

In addition, I found and want to handle values like "track;lane", but only found this in one place.