### PR TITLE
Add better handling for MISSING Cycleway tag

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ev/Cycleway.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Cycleway.java
@@ -1,5 +1,7 @@
 package com.graphhopper.routing.ev;
 
+import com.graphhopper.util.Helper;
+
 public enum Cycleway {
 
   /**
@@ -8,11 +10,11 @@ public enum Cycleway {
    * It is heavily influenced from the cycleway tag in OSM.
    * All edges that do not fit get OTHER as value.
    */
-  OTHER("other"),
+  MISSING("missing"),
   ASL("asl"),
   CROSSING("crossing"),
   LANE("lane"), OPPOSITE_LANE("opposite_lane"),
-  NO("no"),YES("yes"),
+  NO("no"), YES("yes"),
   OPPOSITE("opposite"),
   SEPARATE("separate"),
   SHARE_BUSWAY("share_busway"), OPPOSITE_SHARE_BUSWAY("opposite_share_busway"),
@@ -21,7 +23,8 @@ public enum Cycleway {
   SHOULDER("shoulder"),
   TRACK("track"), OPPOSITE_TRACK("opposite_track"),
   RIGHT("right"), LEFT("left"), BOTH("both"),
-  SIDEPATH("sidepath");
+  SIDEPATH("sidepath"),
+  OTHER("other");
 
   public static final String KEY = "cycleway";
 
@@ -37,15 +40,12 @@ public enum Cycleway {
   }
 
   public static Cycleway find(String name) {
-    if (name == null || name.isEmpty())
+    if (Helper.isEmpty(name))
+      return MISSING;
+    try {
+      return Cycleway.valueOf(Helper.toUpperCase(name));
+    } catch (IllegalArgumentException ex) {
       return OTHER;
-
-    for (Cycleway cycleway : values()) {
-      if (cycleway.name().equalsIgnoreCase(name)) {
-        return cycleway;
-      }
     }
-
-    return OTHER;
   }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
@@ -10,30 +10,30 @@ import com.graphhopper.storage.IntsRef;
 import java.util.List;
 
 public class OSMCyclewayParser implements TagParser {
-  
+
   private final EnumEncodedValue<Cycleway> cyclewayEnc;
 
   public OSMCyclewayParser() {
-      this(new EnumEncodedValue<>(Cycleway.KEY, Cycleway.class));
+    this(new EnumEncodedValue<>(Cycleway.KEY, Cycleway.class));
   }
 
   public OSMCyclewayParser(EnumEncodedValue<Cycleway> cyclewayEnc) {
-      this.cyclewayEnc = cyclewayEnc;
+    this.cyclewayEnc = cyclewayEnc;
   }
 
   @Override
   public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
-      list.add(cyclewayEnc);
+    list.add(cyclewayEnc);
   }
 
   @Override
   public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
-      String cyclewayTag = readerWay.getTag("cycleway");
-      if (cyclewayTag == null)
-        return edgeFlags;
-      Cycleway cycleway = Cycleway.find(cyclewayTag);
-
-      cyclewayEnc.setEnum(false, edgeFlags, cycleway);
+    String cyclewayTag = readerWay.getTag("cycleway");
+    Cycleway cycleway = Cycleway.find(cyclewayTag);
+    if (cycleway == Cycleway.MISSING)
       return edgeFlags;
+
+    cyclewayEnc.setEnum(false, edgeFlags, cycleway);
+    return edgeFlags;
   }
 }


### PR DESCRIPTION
Follow the more modern style of other parsers/evs and have a designated "missing" value.  This value WILL get passed along to the response object, which is the same behavior as other details with a "missing" value.

This isn't critical but I think is something that brings my earlier changes in line with other practices in this repo, so would be nice to include.