### PR TITLE
Parse cycleway:* tag keys in addition to regular cycleway tag

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -469,7 +469,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
                 weightToPrioMap.put(50d, AVOID_MORE.getValue());
         }
 
-        String cycleway = way.getFirstPriorityTag(Arrays.asList("cycleway", "cycleway:left", "cycleway:right"));
+        String cycleway = way.getFirstPriorityTag(Arrays.asList("cycleway", "cycleway:both", "cycleway:left", "cycleway:right"));
         if (Arrays.asList("lane", "shared_lane", "share_busway", "shoulder").contains(cycleway)) {
             weightToPrioMap.put(100d, UNCHANGED.getValue());
         } else if ("track".equals(cycleway)) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
@@ -8,6 +8,7 @@ import com.graphhopper.routing.ev.Cycleway;
 import com.graphhopper.storage.IntsRef;
 
 import java.util.List;
+import java.util.Arrays;
 
 public class OSMCyclewayParser implements TagParser {
 
@@ -28,7 +29,8 @@ public class OSMCyclewayParser implements TagParser {
 
   @Override
   public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
-    String cyclewayTag = readerWay.getTag("cycleway");
+    String cyclewayTag = readerWay
+        .getFirstPriorityTag(Arrays.asList("cycleway", "cycleway:both", "cycleway:left", "cycleway:right"));
     Cycleway cycleway = Cycleway.find(cyclewayTag);
     if (cycleway == Cycleway.MISSING)
       return edgeFlags;


### PR DESCRIPTION
Fixes #24. This is also how the BikeCommonEncoder parses these tags (same order and everything). Tested on my local.

I also opened https://github.com/bikehopper/graphhopper/issues/26 in the process of doing this.