### PR TITLE
Parse cycleway:left and cycleway:right differently

### DIFF
--- a/bay-area/config-local.yml
+++ b/bay-area/config-local.yml
@@ -20,7 +20,7 @@ graphhopper:
   # Default values are: road_class,road_class_link,road_environment,max_speed,road_access (since #1805)
   # More are: surface,smoothness,max_width,max_height,max_weight,max_axle_load,max_length,hazmat,hazmat_tunnel,hazmat_water,toll,track_type,
   #           mtb_rating, hiking_rating,horse_rating,lanes
-  # graph.encoded_values: surface,toll,track_type
+  graph.encoded_values: country
 
   ##### Routing Profiles ####
 
@@ -174,9 +174,9 @@ graphhopper:
   # custom_areas.directory: path/to/custom_areas
 
   ##### Country Rules #####
-  # GraphHopper applies country-specific routing rules (enabled by default) during import.
-  # Use this flag to disable these rules (you need to repeat the import for changes to take effect)
-  # country_rules.enable: false
+  # GraphHopper applies country-specific routing rules (disabled by default) during import.
+  # Use this flag to enable these rules (you need to repeat the import for changes to take effect)
+  country_rules.enabled: true
 
 # Dropwizard server configuration
 server:

--- a/bay-area/config.yml
+++ b/bay-area/config.yml
@@ -21,7 +21,7 @@ graphhopper:
   # Default values are: road_class,road_class_link,road_environment,max_speed,road_access (since #1805)
   # More are: surface,smoothness,max_width,max_height,max_weight,max_axle_load,max_length,hazmat,hazmat_tunnel,hazmat_water,toll,track_type,
   #           mtb_rating, hiking_rating,horse_rating,lanes
-  # graph.encoded_values: surface,toll,track_type
+  graph.encoded_values: country
 
   ##### Routing Profiles ####
 
@@ -177,9 +177,9 @@ graphhopper:
   # custom_areas.directory: path/to/custom_areas
 
   ##### Country Rules #####
-  # GraphHopper applies country-specific routing rules (enabled by default) during import.
-  # Use this flag to disable these rules (you need to repeat the import for changes to take effect)
-  # country_rules.enable: false
+  # GraphHopper applies country-specific routing rules (disabled by default) during import.
+  # Use this flag to enable these rules (you need to repeat the import for changes to take effect)
+  country_rules.enabled: true
 
 # Dropwizard server configuration
 server:

--- a/core/src/main/java/com/graphhopper/routing/ev/DrivingSide.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DrivingSide.java
@@ -1,0 +1,39 @@
+package com.graphhopper.routing.ev;
+
+import com.graphhopper.util.Helper;
+
+public enum DrivingSide {
+  LEFT("left"), RIGHT("right"), OTHER("other"), MISSING("missing");
+
+  private final String name;
+
+  DrivingSide(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  public static DrivingSide find(String name) {
+    if (Helper.isEmpty(name))
+      return MISSING;
+    try {
+      return DrivingSide.valueOf(Helper.toUpperCase(name));
+    } catch (IllegalArgumentException ex) {
+      return OTHER;
+    }
+  }
+
+  public static DrivingSide reverse(DrivingSide drivingSide) {
+    switch (drivingSide) {
+      case LEFT:
+        return RIGHT;
+      case RIGHT:
+        return LEFT;
+      default:
+        return MISSING;
+    }
+  }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/BidirectionalTreeMap.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BidirectionalTreeMap.java
@@ -24,11 +24,11 @@ import java.util.Map.Entry;
  * A simple wrapper around two Maps that stores directionally-aware priority
  * values.
  */
-public class TwoDirectionsPriorityMap {
+public class BidirectionalTreeMap {
   private TreeMap<Double, Integer> forward;
   private TreeMap<Double, Integer> backward;
 
-  TwoDirectionsPriorityMap() {
+  BidirectionalTreeMap() {
     this.forward = new TreeMap<>();
     this.backward = new TreeMap<>();
   }

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -31,8 +31,7 @@ import static com.graphhopper.routing.util.EncodingManager.getKey;
 import static com.graphhopper.routing.util.PriorityCode.*;
 
 /**
- * Defines bit layout of bicycles (not motorcycles) for speed, access and
- * relations (network).
+ * Defines bit layout of bicycles (not motorcycles) for speed, access and relations (network).
  *
  * @author Peter Karich
  * @author Nop
@@ -41,8 +40,7 @@ import static com.graphhopper.routing.util.PriorityCode.*;
 abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
     protected static final int PUSHING_SECTION_SPEED = 4;
-    // Pushing section highways are parts where you need to get off your bike and
-    // push it (German: Schiebestrecke)
+    // Pushing section highways are parts where you need to get off your bike and push it (German: Schiebestrecke)
     protected final HashSet<String> pushingSectionsHighways = new HashSet<>();
     protected final HashSet<String> oppositeLanes = new HashSet<>();
     protected final Set<String> preferHighwayTags = new HashSet<>();
@@ -56,8 +54,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     protected final boolean priorityTwoDirections = true;
     protected boolean speedTwoDirections;
     DecimalEncodedValue priorityEnc;
-    // Car speed limit which switches the preference from UNCHANGED to
-    // AVOID_IF_POSSIBLE
+    // Car speed limit which switches the preference from UNCHANGED to AVOID_IF_POSSIBLE
     private int avoidSpeedLimit;
     EnumEncodedValue<RouteNetwork> bikeRouteEnc;
     EnumEncodedValue<Smoothness> smoothnessEnc;
@@ -116,7 +113,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         setTrackTypeSpeed("grade2", 12); // now unpaved ...
         setTrackTypeSpeed("grade3", 8);
         setTrackTypeSpeed("grade4", 6);
-        setTrackTypeSpeed("grade5", 4); // like sand/grass
+        setTrackTypeSpeed("grade5", 4); // like sand/grass     
 
         setSurfaceSpeed("paved", 18);
         setSurfaceSpeed("asphalt", 18);
@@ -149,7 +146,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         setHighwaySpeed("steps", PUSHING_SECTION_SPEED / 2);
         avoidHighwayTags.add("steps");
 
-        final int CYCLEWAY_SPEED = 18; // Make sure cycleway and path use same speed value, see #634
+        final int CYCLEWAY_SPEED = 18;  // Make sure cycleway and path use same speed value, see #634
         setHighwaySpeed("cycleway", CYCLEWAY_SPEED);
         setHighwaySpeed("path", 10);
         setHighwaySpeed("footway", 6);
@@ -201,8 +198,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     public void createEncodedValues(List<EncodedValue> registerNewEncodedValue, String prefix) {
         // first two bits are reserved for route handling in superclass
         super.createEncodedValues(registerNewEncodedValue, prefix);
-        registerNewEncodedValue.add(avgSpeedEnc = new DecimalEncodedValueImpl(getKey(prefix, "average_speed"),
-                speedBits, speedFactor, speedTwoDirections));
+        registerNewEncodedValue.add(avgSpeedEnc = new DecimalEncodedValueImpl(getKey(prefix, "average_speed"), speedBits, speedFactor, speedTwoDirections));
         registerNewEncodedValue.add(priorityEnc = new DecimalEncodedValueImpl(getKey(prefix, "priority"), 4,
                 PriorityCode.getFactor(1), priorityTwoDirections));
 
@@ -217,8 +213,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             EncodingManager.Access access = EncodingManager.Access.CAN_SKIP;
 
             if (way.hasTag("route", ferries)) {
-                // if bike is NOT explicitly tagged allow bike but only if foot is not specified
-                // either
+                // if bike is NOT explicitly tagged allow bike but only if foot is not specified either
                 String bikeTag = way.getTag("bicycle");
                 if (bikeTag == null && !way.hasTag("foot") || intendedValues.contains(bikeTag))
                     access = EncodingManager.Access.FERRY;
@@ -232,8 +227,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
                 access = EncodingManager.Access.WAY;
 
             if (!access.canSkip()) {
-                if (way.hasTag(restrictions, restrictedValues)
-                        && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
+                if (way.hasTag(restrictions, restrictedValues) && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
                     return EncodingManager.Access.CAN_SKIP;
                 return access;
             }
@@ -268,8 +262,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             return EncodingManager.Access.CAN_SKIP;
 
         // check access restrictions
-        if (way.hasTag(restrictions, restrictedValues)
-                && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
+        if (way.hasTag(restrictions, restrictedValues) && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
             return EncodingManager.Access.CAN_SKIP;
 
         if (getConditionalTagInspector().isPermittedWayConditionallyRestricted(way))
@@ -279,16 +272,13 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     }
 
     boolean isSacScaleAllowed(String sacScale) {
-        // other scales are nearly impossible by an ordinary bike, see
-        // http://wiki.openstreetmap.org/wiki/Key:sac_scale
+        // other scales are nearly impossible by an ordinary bike, see http://wiki.openstreetmap.org/wiki/Key:sac_scale
         return "hiking".equals(sacScale);
     }
 
     /**
-     * Apply maxspeed: In contrast to the implementation of the AbstractFlagEncoder,
-     * we assume that
-     * we can reach the maxspeed for bicycles in case that the road type speed is
-     * higher and not
+     * Apply maxspeed: In contrast to the implementation of the AbstractFlagEncoder, we assume that
+     * we can reach the maxspeed for bicycles in case that the road type speed is higher and not
      * just only 90%.
      *
      * @param way   needed to retrieve tags
@@ -321,9 +311,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             if (smoothness != Smoothness.MISSING) {
                 // smoothness handling: Multiply speed with smoothnessFactor
                 double smoothnessSpeedFactor = smoothnessFactor.get(smoothness);
-                wayTypeSpeed = (smoothnessSpeedFactor <= smoothnessFactorPushingSectionThreshold)
-                        ? PUSHING_SECTION_SPEED
-                        : Math.round(smoothnessSpeedFactor * wayTypeSpeed);
+                wayTypeSpeed = (smoothnessSpeedFactor <= smoothnessFactorPushingSectionThreshold) ?
+                        PUSHING_SECTION_SPEED : Math.round(smoothnessSpeedFactor * wayTypeSpeed);
             }
             handleSpeed(edgeFlags, way, wayTypeSpeed);
         } else {
@@ -334,9 +323,6 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             priorityFromRelation = SLIGHT_AVOID.getValue();
         }
 
-        // priorityEnc.setDecimal(false, edgeFlags,
-        // PriorityCode.getValue(handlePriority(way, wayTypeSpeed,
-        // priorityFromRelation)));
         handlePriority(edgeFlags, way, wayTypeSpeed, priorityFromRelation);
         return edgeFlags;
     }
@@ -346,11 +332,10 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         String highwayTag = way.getTag("highway");
         Integer highwaySpeed = highwaySpeeds.get(highwayTag);
 
-        // Under certain conditions we need to increase the speed of pushing sections to
-        // the speed of a "highway=cycleway"
+        // Under certain conditions we need to increase the speed of pushing sections to the speed of a "highway=cycleway"
         if (way.hasTag("highway", pushingSectionsHighways)
                 && ((way.hasTag("foot", "yes") && way.hasTag("segregated", "yes"))
-                        || (way.hasTag("bicycle", intendedValues))))
+                || (way.hasTag("bicycle", intendedValues))))
             highwaySpeed = getHighwaySpeed("cycleway");
 
         String s = way.getTag("surface");
@@ -382,25 +367,21 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         }
 
         // Until now we assumed that the way is no pushing section
-        // Now we check that, but only in case that our speed computed so far is bigger
-        // compared to the PUSHING_SECTION_SPEED
+        // Now we check that, but only in case that our speed computed so far is bigger compared to the PUSHING_SECTION_SPEED
         if (speed > PUSHING_SECTION_SPEED
                 && (way.hasTag("highway", pushingSectionsHighways) || way.hasTag("bicycle", "dismount"))) {
             if (!way.hasTag("bicycle", intendedValues)) {
-                // Here we set the speed for pushing sections and set speed for steps as even
-                // lower:
+                // Here we set the speed for pushing sections and set speed for steps as even lower:
                 speed = way.hasTag("highway", "steps") ? PUSHING_SECTION_SPEED / 2 : PUSHING_SECTION_SPEED;
             } else if (way.hasTag("bicycle", "designated") || way.hasTag("bicycle", "official") ||
                     way.hasTag("segregated", "yes") || way.hasTag("bicycle", "yes")) {
-                // Here we handle the cases where the OSM tagging results in something similar
-                // to "highway=cycleway"
+                // Here we handle the cases where the OSM tagging results in something similar to "highway=cycleway"
                 if (way.hasTag("segregated", "yes"))
                     speed = highwaySpeeds.get("cycleway");
                 else
                     speed = way.hasTag("bicycle", "yes") ? 10 : highwaySpeeds.get("cycleway");
 
-                // overwrite our speed again in case we have a valid surface speed and if it is
-                // smaller as computed so far
+                // overwrite our speed again in case we have a valid surface speed and if it is smaller as computed so far
                 if ((surfaceSpeed > 0) && (surfaceSpeed < speed))
                     speed = surfaceSpeed;
             }
@@ -410,11 +391,10 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
     /**
      * In this method we prefer cycleways or roads with designated bike access and
-     * avoid big roads
-     * or roads with trams or pedestrian.
+     * avoid big roads or roads with trams or pedestrian.
      *
-     * @return new priority based on priorityFromRelation and on the tags in
-     *         ReaderWay.
+     * Modifies priorityEnc with a new priority based on priorityFromRelation and on
+     * the tags in ReaderWay.
      */
     void handlePriority(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, Integer priorityFromRelation) {
         TwoDirectionsPriorityMap weightToPrioMap = new TwoDirectionsPriorityMap();
@@ -429,8 +409,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         priorityEnc.setDecimal(true, edgeFlags, PriorityCode.getValue(weightToPrioMap.lastEntry(true).getValue()));
     }
 
-    // Conversion of class value to priority. See
-    // http://wiki.openstreetmap.org/wiki/Class:bicycle
+    // Conversion of class value to priority. See http://wiki.openstreetmap.org/wiki/Class:bicycle
     private PriorityCode convertClassValueToPriority(String tagvalue) {
         int classvalue;
         try {
@@ -460,11 +439,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     }
 
     /**
-     * @param weightToPrioMap associate a weight with every priority. This sorted
-     *                        map allows
-     *                        subclasses to 'insert' more important
-     *                        priorities as well as overwrite determined
-     *                        priorities.
+     * @param weightToPrioMap associate a weight with every priority. This sorted map allows
+     *                        subclasses to 'insert' more important priorities as well as overwrite determined priorities.
      */
     void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, TwoDirectionsPriorityMap weightToPrioMap) {
         String service = way.getTag("service");
@@ -556,8 +532,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
         String classBicycleValue = way.getTag(classBicycleKey);
         if (classBicycleValue != null) {
-            // We assume that humans are better in classifying preferences compared to our
-            // algorithm above -> weight = 100
+            // We assume that humans are better in classifying preferences compared to our algorithm above -> weight = 100
             weightToPrioMap.put(100d, convertClassValueToPriority(classBicycleValue).getValue());
         } else {
             String classBicycle = way.getTag("class:bicycle");
@@ -565,8 +540,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
                 weightToPrioMap.put(100d, convertClassValueToPriority(classBicycle).getValue());
         }
 
-        // Increase the priority for scenic routes or in case that maxspeed limits our
-        // average speed as compensation. See #630
+        // Increase the priority for scenic routes or in case that maxspeed limits our average speed as compensation. See #630
         if (way.hasTag("scenic", "yes") || maxSpeed > 0 && maxSpeed < wayTypeSpeed) {
             if (weightToPrioMap.lastEntry(false).getValue() < BEST.getValue())
                 // Increase the prio by one step
@@ -579,8 +553,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
         // handle oneways
         // oneway=-1 requires special handling
-        boolean isOneway = (way.hasTag("oneway", oneways) && !way.hasTag("oneway", "-1")
-                && !way.hasTag("bicycle:backward", intendedValues))
+        boolean isOneway = (way.hasTag("oneway", oneways) && !way.hasTag("oneway", "-1") && !way.hasTag("bicycle:backward", intendedValues))
                 || (way.hasTag("oneway", "-1") && !way.hasTag("bicycle:forward", intendedValues))
                 || way.hasTag("oneway:bicycle", oneways)
                 || (way.hasTag("vehicle:backward", restrictedValues) && !way.hasTag("bicycle:forward", intendedValues))

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -481,25 +481,25 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
                 weightToPrioMap.put(50d, AVOID_MORE.getValue());
         }
 
-        String cycleway = way.getFirstPriorityTag(Arrays.asList("cycleway", "cycleway:both"));
-
         // Determine the forward cycleway side from country rules
         DrivingSide drivingSide = DrivingSide.find(way.getTag("driving_side"));
         CountryRule countryRule = way.getTag("country_rule", null);
         if (countryRule != null) {
             drivingSide = countryRule.getDrivingSide(way, drivingSide);
         }
-        String cyclewayForward = way.getTag("cycleway:" + drivingSide.toString());
-        String cyclewayBackward = way.getTag("cycleway:" + DrivingSide.reverse(drivingSide).toString());
-        boolean isOneway = isOneway(way) || roundaboutEnc.getBool(false, edgeFlags);
+
+        String cycleway = way.getFirstPriorityTag(Arrays.asList("cycleway", "cycleway:both")),
+                cyclewayForward = way.getTag("cycleway:" + drivingSide.toString()),
+                cyclewayBackward = way.getTag("cycleway:" + DrivingSide.reverse(drivingSide).toString());
 
         Integer cyclewayPriority = cyclewayMap.get(cycleway),
                 cyclewayForwardPriority = cyclewayMap.get(cyclewayForward),
                 cyclewayBackwardPriority = cyclewayMap.get(cyclewayBackward);
+
         if (Objects.nonNull(cyclewayPriority)) {
             weightToPrioMap.put(100d, cyclewayPriority);
         }
-        if (isOneway) {
+        if (isOneway(way) || roundaboutEnc.getBool(false, edgeFlags)) {
             // On oneway streets, any accessible infrastructure works
             Stream.of(cyclewayForwardPriority, cyclewayBackwardPriority)
                     .filter(Objects::nonNull)

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -405,7 +405,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
      * the tags in ReaderWay.
      */
     void handlePriority(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, Integer priorityFromRelation) {
-        TwoDirectionsPriorityMap weightToPrioMap = new TwoDirectionsPriorityMap();
+        BidirectionalTreeMap weightToPrioMap = new BidirectionalTreeMap();
         if (priorityFromRelation == null)
             weightToPrioMap.put(0d, UNCHANGED.getValue());
         else
@@ -450,7 +450,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
      * @param weightToPrioMap associate a weight with every priority. This sorted map allows
      *                        subclasses to 'insert' more important priorities as well as overwrite determined priorities.
      */
-    void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, TwoDirectionsPriorityMap weightToPrioMap) {
+    void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, BidirectionalTreeMap weightToPrioMap) {
         String service = way.getTag("service");
         String highway = way.getTag("highway");
         if (way.hasTag("bicycle", "designated") || way.hasTag("bicycle", "official")) {

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -30,7 +30,8 @@ import static com.graphhopper.routing.util.EncodingManager.getKey;
 import static com.graphhopper.routing.util.PriorityCode.*;
 
 /**
- * Defines bit layout of bicycles (not motorcycles) for speed, access and relations (network).
+ * Defines bit layout of bicycles (not motorcycles) for speed, access and
+ * relations (network).
  *
  * @author Peter Karich
  * @author Nop
@@ -39,7 +40,8 @@ import static com.graphhopper.routing.util.PriorityCode.*;
 abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
     protected static final int PUSHING_SECTION_SPEED = 4;
-    // Pushing section highways are parts where you need to get off your bike and push it (German: Schiebestrecke)
+    // Pushing section highways are parts where you need to get off your bike and
+    // push it (German: Schiebestrecke)
     protected final HashSet<String> pushingSectionsHighways = new HashSet<>();
     protected final HashSet<String> oppositeLanes = new HashSet<>();
     protected final Set<String> preferHighwayTags = new HashSet<>();
@@ -50,9 +52,11 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     protected static final double smoothnessFactorPushingSectionThreshold = 0.3d;
     private final Map<Smoothness, Double> smoothnessFactor = new HashMap<>();
     private final Map<String, Integer> highwaySpeeds = new HashMap<>();
+    protected final boolean priorityTwoDirections = true;
     protected boolean speedTwoDirections;
     DecimalEncodedValue priorityEnc;
-    // Car speed limit which switches the preference from UNCHANGED to AVOID_IF_POSSIBLE
+    // Car speed limit which switches the preference from UNCHANGED to
+    // AVOID_IF_POSSIBLE
     private int avoidSpeedLimit;
     EnumEncodedValue<RouteNetwork> bikeRouteEnc;
     EnumEncodedValue<Smoothness> smoothnessEnc;
@@ -111,7 +115,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         setTrackTypeSpeed("grade2", 12); // now unpaved ...
         setTrackTypeSpeed("grade3", 8);
         setTrackTypeSpeed("grade4", 6);
-        setTrackTypeSpeed("grade5", 4); // like sand/grass     
+        setTrackTypeSpeed("grade5", 4); // like sand/grass
 
         setSurfaceSpeed("paved", 18);
         setSurfaceSpeed("asphalt", 18);
@@ -144,7 +148,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         setHighwaySpeed("steps", PUSHING_SECTION_SPEED / 2);
         avoidHighwayTags.add("steps");
 
-        final int CYCLEWAY_SPEED = 18;  // Make sure cycleway and path use same speed value, see #634
+        final int CYCLEWAY_SPEED = 18; // Make sure cycleway and path use same speed value, see #634
         setHighwaySpeed("cycleway", CYCLEWAY_SPEED);
         setHighwaySpeed("path", 10);
         setHighwaySpeed("footway", 6);
@@ -196,8 +200,10 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     public void createEncodedValues(List<EncodedValue> registerNewEncodedValue, String prefix) {
         // first two bits are reserved for route handling in superclass
         super.createEncodedValues(registerNewEncodedValue, prefix);
-        registerNewEncodedValue.add(avgSpeedEnc = new DecimalEncodedValueImpl(getKey(prefix, "average_speed"), speedBits, speedFactor, speedTwoDirections));
-        registerNewEncodedValue.add(priorityEnc = new DecimalEncodedValueImpl(getKey(prefix, "priority"), 4, PriorityCode.getFactor(1), false));
+        registerNewEncodedValue.add(avgSpeedEnc = new DecimalEncodedValueImpl(getKey(prefix, "average_speed"),
+                speedBits, speedFactor, speedTwoDirections));
+        registerNewEncodedValue.add(priorityEnc = new DecimalEncodedValueImpl(getKey(prefix, "priority"), 4,
+                PriorityCode.getFactor(1), priorityTwoDirections));
 
         bikeRouteEnc = getEnumEncodedValue(RouteNetwork.key("bike"), RouteNetwork.class);
         smoothnessEnc = getEnumEncodedValue(Smoothness.KEY, Smoothness.class);
@@ -210,7 +216,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             EncodingManager.Access access = EncodingManager.Access.CAN_SKIP;
 
             if (way.hasTag("route", ferries)) {
-                // if bike is NOT explicitly tagged allow bike but only if foot is not specified either
+                // if bike is NOT explicitly tagged allow bike but only if foot is not specified
+                // either
                 String bikeTag = way.getTag("bicycle");
                 if (bikeTag == null && !way.hasTag("foot") || intendedValues.contains(bikeTag))
                     access = EncodingManager.Access.FERRY;
@@ -224,7 +231,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
                 access = EncodingManager.Access.WAY;
 
             if (!access.canSkip()) {
-                if (way.hasTag(restrictions, restrictedValues) && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
+                if (way.hasTag(restrictions, restrictedValues)
+                        && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
                     return EncodingManager.Access.CAN_SKIP;
                 return access;
             }
@@ -259,7 +267,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             return EncodingManager.Access.CAN_SKIP;
 
         // check access restrictions
-        if (way.hasTag(restrictions, restrictedValues) && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
+        if (way.hasTag(restrictions, restrictedValues)
+                && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
             return EncodingManager.Access.CAN_SKIP;
 
         if (getConditionalTagInspector().isPermittedWayConditionallyRestricted(way))
@@ -269,13 +278,16 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     }
 
     boolean isSacScaleAllowed(String sacScale) {
-        // other scales are nearly impossible by an ordinary bike, see http://wiki.openstreetmap.org/wiki/Key:sac_scale
+        // other scales are nearly impossible by an ordinary bike, see
+        // http://wiki.openstreetmap.org/wiki/Key:sac_scale
         return "hiking".equals(sacScale);
     }
 
     /**
-     * Apply maxspeed: In contrast to the implementation of the AbstractFlagEncoder, we assume that
-     * we can reach the maxspeed for bicycles in case that the road type speed is higher and not
+     * Apply maxspeed: In contrast to the implementation of the AbstractFlagEncoder,
+     * we assume that
+     * we can reach the maxspeed for bicycles in case that the road type speed is
+     * higher and not
      * just only 90%.
      *
      * @param way   needed to retrieve tags
@@ -308,8 +320,9 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             if (smoothness != Smoothness.MISSING) {
                 // smoothness handling: Multiply speed with smoothnessFactor
                 double smoothnessSpeedFactor = smoothnessFactor.get(smoothness);
-                wayTypeSpeed = (smoothnessSpeedFactor <= smoothnessFactorPushingSectionThreshold) ?
-                        PUSHING_SECTION_SPEED : Math.round(smoothnessSpeedFactor * wayTypeSpeed);
+                wayTypeSpeed = (smoothnessSpeedFactor <= smoothnessFactorPushingSectionThreshold)
+                        ? PUSHING_SECTION_SPEED
+                        : Math.round(smoothnessSpeedFactor * wayTypeSpeed);
             }
             handleSpeed(edgeFlags, way, wayTypeSpeed);
         } else {
@@ -320,7 +333,10 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             priorityFromRelation = SLIGHT_AVOID.getValue();
         }
 
-        priorityEnc.setDecimal(false, edgeFlags, PriorityCode.getValue(handlePriority(way, wayTypeSpeed, priorityFromRelation)));
+        // priorityEnc.setDecimal(false, edgeFlags,
+        // PriorityCode.getValue(handlePriority(way, wayTypeSpeed,
+        // priorityFromRelation)));
+        handlePriority(edgeFlags, way, wayTypeSpeed, priorityFromRelation);
         return edgeFlags;
     }
 
@@ -329,10 +345,11 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         String highwayTag = way.getTag("highway");
         Integer highwaySpeed = highwaySpeeds.get(highwayTag);
 
-        // Under certain conditions we need to increase the speed of pushing sections to the speed of a "highway=cycleway"
+        // Under certain conditions we need to increase the speed of pushing sections to
+        // the speed of a "highway=cycleway"
         if (way.hasTag("highway", pushingSectionsHighways)
                 && ((way.hasTag("foot", "yes") && way.hasTag("segregated", "yes"))
-                || (way.hasTag("bicycle", intendedValues))))
+                        || (way.hasTag("bicycle", intendedValues))))
             highwaySpeed = getHighwaySpeed("cycleway");
 
         String s = way.getTag("surface");
@@ -364,21 +381,25 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         }
 
         // Until now we assumed that the way is no pushing section
-        // Now we check that, but only in case that our speed computed so far is bigger compared to the PUSHING_SECTION_SPEED
+        // Now we check that, but only in case that our speed computed so far is bigger
+        // compared to the PUSHING_SECTION_SPEED
         if (speed > PUSHING_SECTION_SPEED
                 && (way.hasTag("highway", pushingSectionsHighways) || way.hasTag("bicycle", "dismount"))) {
             if (!way.hasTag("bicycle", intendedValues)) {
-                // Here we set the speed for pushing sections and set speed for steps as even lower:
+                // Here we set the speed for pushing sections and set speed for steps as even
+                // lower:
                 speed = way.hasTag("highway", "steps") ? PUSHING_SECTION_SPEED / 2 : PUSHING_SECTION_SPEED;
             } else if (way.hasTag("bicycle", "designated") || way.hasTag("bicycle", "official") ||
                     way.hasTag("segregated", "yes") || way.hasTag("bicycle", "yes")) {
-                // Here we handle the cases where the OSM tagging results in something similar to "highway=cycleway"
+                // Here we handle the cases where the OSM tagging results in something similar
+                // to "highway=cycleway"
                 if (way.hasTag("segregated", "yes"))
                     speed = highwaySpeeds.get("cycleway");
                 else
                     speed = way.hasTag("bicycle", "yes") ? 10 : highwaySpeeds.get("cycleway");
 
-                // overwrite our speed again in case we have a valid surface speed and if it is smaller as computed so far
+                // overwrite our speed again in case we have a valid surface speed and if it is
+                // smaller as computed so far
                 if ((surfaceSpeed > 0) && (surfaceSpeed < speed))
                     speed = surfaceSpeed;
             }
@@ -387,25 +408,28 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     }
 
     /**
-     * In this method we prefer cycleways or roads with designated bike access and avoid big roads
+     * In this method we prefer cycleways or roads with designated bike access and
+     * avoid big roads
      * or roads with trams or pedestrian.
      *
-     * @return new priority based on priorityFromRelation and on the tags in ReaderWay.
+     * @return new priority based on priorityFromRelation and on the tags in
+     *         ReaderWay.
      */
-    int handlePriority(ReaderWay way, double wayTypeSpeed, Integer priorityFromRelation) {
-        TreeMap<Double, Integer> weightToPrioMap = new TreeMap<>();
+    void handlePriority(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, Integer priorityFromRelation) {
+        TwoDirectionsPriorityMap weightToPrioMap = new TwoDirectionsPriorityMap();
         if (priorityFromRelation == null)
             weightToPrioMap.put(0d, UNCHANGED.getValue());
         else
             weightToPrioMap.put(110d, priorityFromRelation);
 
-        collect(way, wayTypeSpeed, weightToPrioMap);
+        collect(edgeFlags, way, wayTypeSpeed, weightToPrioMap);
 
-        // pick priority with biggest order value
-        return weightToPrioMap.lastEntry().getValue();
+        priorityEnc.setDecimal(false, edgeFlags, PriorityCode.getValue(weightToPrioMap.lastEntry(false).getValue()));
+        priorityEnc.setDecimal(true, edgeFlags, PriorityCode.getValue(weightToPrioMap.lastEntry(true).getValue()));
     }
 
-    // Conversion of class value to priority. See http://wiki.openstreetmap.org/wiki/Class:bicycle
+    // Conversion of class value to priority. See
+    // http://wiki.openstreetmap.org/wiki/Class:bicycle
     private PriorityCode convertClassValueToPriority(String tagvalue) {
         int classvalue;
         try {
@@ -435,10 +459,13 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     }
 
     /**
-     * @param weightToPrioMap associate a weight with every priority. This sorted map allows
-     *                        subclasses to 'insert' more important priorities as well as overwrite determined priorities.
+     * @param weightToPrioMap associate a weight with every priority. This sorted
+     *                        map allows
+     *                        subclasses to 'insert' more important
+     *                        priorities as well as overwrite determined
+     *                        priorities.
      */
-    void collect(ReaderWay way, double wayTypeSpeed, TreeMap<Double, Integer> weightToPrioMap) {
+    void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, TwoDirectionsPriorityMap weightToPrioMap) {
         String service = way.getTag("service");
         String highway = way.getTag("highway");
         if (way.hasTag("bicycle", "designated") || way.hasTag("bicycle", "official")) {
@@ -469,11 +496,41 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
                 weightToPrioMap.put(50d, AVOID_MORE.getValue());
         }
 
-        String cycleway = way.getFirstPriorityTag(Arrays.asList("cycleway", "cycleway:both", "cycleway:left", "cycleway:right"));
+        String cycleway = way.getFirstPriorityTag(Arrays.asList("cycleway", "cycleway:both"));
+        String cyclewayLeft = way.getTag("cycleway:left");
+        String cyclewayRight = way.getTag("cycleway:right");
         if (Arrays.asList("lane", "shared_lane", "share_busway", "shoulder").contains(cycleway)) {
             weightToPrioMap.put(100d, UNCHANGED.getValue());
+        } else if (Arrays.asList("lane", "shared_lane", "share_busway", "shoulder").contains(cyclewayLeft)) {
+            // On bidirectional streets in US, left is reverse
+            weightToPrioMap.put(true, 100d, UNCHANGED.getValue());
+            if (isOneway(way) || roundaboutEnc.getBool(false, edgeFlags)) {
+                // On oneway streets, any accessible infrastructure works
+                weightToPrioMap.put(false, 100d, UNCHANGED.getValue());
+            }
+        } else if (Arrays.asList("lane", "shared_lane", "share_busway", "shoulder").contains(cyclewayRight)) {
+            // On bidirectional streets in US, right is forward
+            weightToPrioMap.put(false, 100d, UNCHANGED.getValue());
+            if (isOneway(way) || roundaboutEnc.getBool(false, edgeFlags)) {
+                // On oneway streets, any accessible infrastructure works
+                weightToPrioMap.put(true, 100d, UNCHANGED.getValue());
+            }
         } else if ("track".equals(cycleway)) {
             weightToPrioMap.put(100d, PREFER.getValue());
+        } else if ("track".equals(cyclewayLeft)) {
+            // On bidirectional streets in US, left is reverse
+            weightToPrioMap.put(true, 100d, PREFER.getValue());
+            if (isOneway(way) || roundaboutEnc.getBool(false, edgeFlags)) {
+                // On oneway streets, any accessible infrastructure works
+                weightToPrioMap.put(false, 100d, PREFER.getValue());
+            }
+        } else if ("track".equals(cyclewayRight)) {
+            // On bidirectional streets in US, right is forward
+            weightToPrioMap.put(false, 100d, PREFER.getValue());
+            if (isOneway(way) || roundaboutEnc.getBool(false, edgeFlags)) {
+                // On oneway streets, any accessible infrastructure works
+                weightToPrioMap.put(true, 100d, PREFER.getValue());
+            }
         }
 
         if (way.hasTag("bicycle", "use_sidepath")) {
@@ -500,7 +557,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
         String classBicycleValue = way.getTag(classBicycleKey);
         if (classBicycleValue != null) {
-            // We assume that humans are better in classifying preferences compared to our algorithm above -> weight = 100
+            // We assume that humans are better in classifying preferences compared to our
+            // algorithm above -> weight = 100
             weightToPrioMap.put(100d, convertClassValueToPriority(classBicycleValue).getValue());
         } else {
             String classBicycle = way.getTag("class:bicycle");
@@ -508,11 +566,12 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
                 weightToPrioMap.put(100d, convertClassValueToPriority(classBicycle).getValue());
         }
 
-        // Increase the priority for scenic routes or in case that maxspeed limits our average speed as compensation. See #630
+        // Increase the priority for scenic routes or in case that maxspeed limits our
+        // average speed as compensation. See #630
         if (way.hasTag("scenic", "yes") || maxSpeed > 0 && maxSpeed < wayTypeSpeed) {
-            if (weightToPrioMap.lastEntry().getValue() < BEST.getValue())
+            if (weightToPrioMap.lastEntry(false).getValue() < BEST.getValue())
                 // Increase the prio by one step
-                weightToPrioMap.put(110d, weightToPrioMap.lastEntry().getValue() + 1);
+                weightToPrioMap.put(110d, weightToPrioMap.lastEntry(false).getValue() + 1);
         }
     }
 
@@ -521,7 +580,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
         // handle oneways
         // oneway=-1 requires special handling
-        boolean isOneway = (way.hasTag("oneway", oneways) && !way.hasTag("oneway", "-1") && !way.hasTag("bicycle:backward", intendedValues))
+        boolean isOneway = (way.hasTag("oneway", oneways) && !way.hasTag("oneway", "-1")
+                && !way.hasTag("bicycle:backward", intendedValues))
                 || (way.hasTag("oneway", "-1") && !way.hasTag("bicycle:forward", intendedValues))
                 || way.hasTag("oneway:bicycle", oneways)
                 || (way.hasTag("vehicle:backward", restrictedValues) && !way.hasTag("bicycle:forward", intendedValues))
@@ -586,5 +646,46 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
     void setSpecificClassBicycle(String subkey) {
         classBicycleKey = "class:bicycle:" + subkey;
+    }
+
+    /**
+     * make sure that isOneway is called before
+     */
+    protected boolean isBackwardOneway(ReaderWay way) {
+        return way.hasTag("oneway", "-1")
+                || way.hasTag("oneway:bicycle", "-1")
+                || way.hasTag("cycleway:left:oneway", "-1")
+                || way.hasTag("cycleway:right:oneway", "-1")
+                || way.hasTag("vehicle:forward", restrictedValues)
+                || way.hasTag("bicycle:forward", restrictedValues)
+                || way.hasTag("cycleway", oppositeLanes)
+                || way.hasTag("cycleway:left", oppositeLanes)
+                || way.hasTag("cycleway:right", oppositeLanes);
+    }
+
+    /**
+     * make sure that isOneway is called before
+     */
+    protected boolean isForwardOneway(ReaderWay way) {
+        return !way.hasTag("oneway", "-1")
+                && !way.hasTag("oneway:bicycle", "-1")
+                && !way.hasTag("cycleway:left:oneway", "-1")
+                && !way.hasTag("cycleway:right:oneway", "-1")
+                && !way.hasTag("vehicle:forward", restrictedValues)
+                && !way.hasTag("bicycle:forward", restrictedValues)
+                && !way.hasTag("cycleway", oppositeLanes)
+                && !way.hasTag("cycleway:left", oppositeLanes)
+                && !way.hasTag("cycleway:right", oppositeLanes);
+    }
+
+    protected boolean isOneway(ReaderWay way) {
+        return way.hasTag("oneway", oneways)
+                || way.hasTag("oneway:bicycle", oneways)
+                || way.hasTag("cycleway:left:oneway", oneways)
+                || way.hasTag("cycleway:right:oneway", oneways)
+                || way.hasTag("vehicle:backward", restrictedValues)
+                || way.hasTag("vehicle:forward", restrictedValues)
+                || way.hasTag("bicycle:backward", restrictedValues)
+                || way.hasTag("bicycle:forward", restrictedValues);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
@@ -21,8 +21,6 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.PMap;
 
-import java.util.TreeMap;
-
 import static com.graphhopper.routing.ev.RouteNetwork.*;
 import static com.graphhopper.routing.util.PriorityCode.*;
 
@@ -53,7 +51,7 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
         setTrackTypeSpeed("grade2", 16); // now unpaved ...
         setTrackTypeSpeed("grade3", 12);
         setTrackTypeSpeed("grade4", 8);
-        setTrackTypeSpeed("grade5", 6); // like sand/grass
+        setTrackTypeSpeed("grade5", 6); // like sand/grass     
 
         setSurfaceSpeed("paved", 18);
         setSurfaceSpeed("asphalt", 18);
@@ -135,10 +133,8 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_BAD, 0.6d);
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.HORRIBLE, 0.5d);
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_HORRIBLE, 0.4d);
-        // SmoothnessSpeed <= smoothnessFactorPushingSectionThreshold gets mapped to
-        // speed PUSHING_SECTION_SPEED
-        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.IMPASSABLE,
-                smoothnessFactorPushingSectionThreshold);
+        // SmoothnessSpeed <= smoothnessFactorPushingSectionThreshold gets mapped to speed PUSHING_SECTION_SPEED
+        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.IMPASSABLE, smoothnessFactorPushingSectionThreshold);
 
         passByDefaultBarriers.add("kissing_gate");
         passByDefaultBarriers.add("stile");
@@ -165,8 +161,7 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
 
     @Override
     boolean isSacScaleAllowed(String sacScale) {
-        // other scales are too dangerous even for MTB, see
-        // http://wiki.openstreetmap.org/wiki/Key:sac_scale
+        // other scales are too dangerous even for MTB, see http://wiki.openstreetmap.org/wiki/Key:sac_scale
         return "hiking".equals(sacScale) || "mountain_hiking".equals(sacScale)
                 || "demanding_mountain_hiking".equals(sacScale) || "alpine_hiking".equals(sacScale);
     }

--- a/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.PMap;
 
 import java.util.TreeMap;
@@ -52,7 +53,7 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
         setTrackTypeSpeed("grade2", 16); // now unpaved ...
         setTrackTypeSpeed("grade3", 12);
         setTrackTypeSpeed("grade4", 8);
-        setTrackTypeSpeed("grade5", 6); // like sand/grass     
+        setTrackTypeSpeed("grade5", 6); // like sand/grass
 
         setSurfaceSpeed("paved", 18);
         setSurfaceSpeed("asphalt", 18);
@@ -134,8 +135,10 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_BAD, 0.6d);
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.HORRIBLE, 0.5d);
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_HORRIBLE, 0.4d);
-        // SmoothnessSpeed <= smoothnessFactorPushingSectionThreshold gets mapped to speed PUSHING_SECTION_SPEED
-        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.IMPASSABLE, smoothnessFactorPushingSectionThreshold);
+        // SmoothnessSpeed <= smoothnessFactorPushingSectionThreshold gets mapped to
+        // speed PUSHING_SECTION_SPEED
+        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.IMPASSABLE,
+                smoothnessFactorPushingSectionThreshold);
 
         passByDefaultBarriers.add("kissing_gate");
         passByDefaultBarriers.add("stile");
@@ -145,8 +148,8 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     @Override
-    void collect(ReaderWay way, double wayTypeSpeed, TreeMap<Double, Integer> weightToPrioMap) {
-        super.collect(way, wayTypeSpeed, weightToPrioMap);
+    void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, TwoDirectionsPriorityMap weightToPrioMap) {
+        super.collect(edgeFlags, way, wayTypeSpeed, weightToPrioMap);
 
         String highway = way.getTag("highway");
         if ("track".equals(highway)) {
@@ -162,7 +165,8 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
 
     @Override
     boolean isSacScaleAllowed(String sacScale) {
-        // other scales are too dangerous even for MTB, see http://wiki.openstreetmap.org/wiki/Key:sac_scale
+        // other scales are too dangerous even for MTB, see
+        // http://wiki.openstreetmap.org/wiki/Key:sac_scale
         return "hiking".equals(sacScale) || "mountain_hiking".equals(sacScale)
                 || "demanding_mountain_hiking".equals(sacScale) || "alpine_hiking".equals(sacScale);
     }

--- a/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
@@ -144,7 +144,7 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     @Override
-    void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, TwoDirectionsPriorityMap weightToPrioMap) {
+    void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, BidirectionalTreeMap weightToPrioMap) {
         super.collect(edgeFlags, way, wayTypeSpeed, weightToPrioMap);
 
         String highway = way.getTag("highway");

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -21,8 +21,6 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.PMap;
 
-import java.util.TreeMap;
-
 import static com.graphhopper.routing.ev.RouteNetwork.*;
 import static com.graphhopper.routing.util.PriorityCode.*;
 
@@ -117,14 +115,10 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.GOOD, 1.0d);
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.INTERMEDIATE, 0.9d);
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.BAD, 0.7d);
-        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_BAD,
-                smoothnessFactorPushingSectionThreshold);
-        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.HORRIBLE,
-                smoothnessFactorPushingSectionThreshold);
-        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_HORRIBLE,
-                smoothnessFactorPushingSectionThreshold);
-        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.IMPASSABLE,
-                smoothnessFactorPushingSectionThreshold);
+        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_BAD, smoothnessFactorPushingSectionThreshold);
+        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.HORRIBLE, smoothnessFactorPushingSectionThreshold);
+        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_HORRIBLE, smoothnessFactorPushingSectionThreshold);
+        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.IMPASSABLE, smoothnessFactorPushingSectionThreshold);
 
         routeMap.put(INTERNATIONAL, BEST.getValue());
         routeMap.put(NATIONAL, BEST.getValue());

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.PMap;
 
 import java.util.TreeMap;
@@ -116,10 +117,14 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.GOOD, 1.0d);
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.INTERMEDIATE, 0.9d);
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.BAD, 0.7d);
-        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_BAD, smoothnessFactorPushingSectionThreshold);
-        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.HORRIBLE, smoothnessFactorPushingSectionThreshold);
-        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_HORRIBLE, smoothnessFactorPushingSectionThreshold);
-        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.IMPASSABLE, smoothnessFactorPushingSectionThreshold);
+        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_BAD,
+                smoothnessFactorPushingSectionThreshold);
+        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.HORRIBLE,
+                smoothnessFactorPushingSectionThreshold);
+        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.VERY_HORRIBLE,
+                smoothnessFactorPushingSectionThreshold);
+        setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.IMPASSABLE,
+                smoothnessFactorPushingSectionThreshold);
 
         routeMap.put(INTERNATIONAL, BEST.getValue());
         routeMap.put(NATIONAL, BEST.getValue());
@@ -135,8 +140,8 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     @Override
-    void collect(ReaderWay way, double wayTypeSpeed, TreeMap<Double, Integer> weightToPrioMap) {
-        super.collect(way, wayTypeSpeed, weightToPrioMap);
+    void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, TwoDirectionsPriorityMap weightToPrioMap) {
+        super.collect(edgeFlags, way, wayTypeSpeed, weightToPrioMap);
 
         String highway = way.getTag("highway");
         if ("service".equals(highway)) {

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -134,7 +134,7 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     @Override
-    void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, TwoDirectionsPriorityMap weightToPrioMap) {
+    void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, BidirectionalTreeMap weightToPrioMap) {
         super.collect(edgeFlags, way, wayTypeSpeed, weightToPrioMap);
 
         String highway = way.getTag("highway");

--- a/core/src/main/java/com/graphhopper/routing/util/TwoDirectionsPriorityMap.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TwoDirectionsPriorityMap.java
@@ -1,0 +1,55 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util;
+
+import java.util.TreeMap;
+import java.util.Map.Entry;
+
+/**
+ * A simple wrapper around two Maps that stores directionally-aware priority
+ * values.
+ */
+public class TwoDirectionsPriorityMap {
+  private TreeMap<Double, Integer> forward;
+  private TreeMap<Double, Integer> backward;
+
+  TwoDirectionsPriorityMap() {
+    this.forward = new TreeMap<>();
+    this.backward = new TreeMap<>();
+  }
+
+  public void put(boolean reverse, Double key, Integer value) {
+    if (reverse) {
+      this.backward.put(key, value);
+    } else {
+      this.forward.put(key, value);
+    }
+  }
+
+  public void put(Double key, Integer value) {
+    this.forward.put(key, value);
+    this.backward.put(key, value);
+  }
+
+  public Entry<Double, Integer> lastEntry(boolean reverse) {
+    if (reverse) {
+      return this.backward.lastEntry();
+    }
+    return this.forward.lastEntry();
+  }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
@@ -19,6 +19,7 @@
 package com.graphhopper.routing.util.countryrules;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.DrivingSide;
 import com.graphhopper.routing.ev.RoadAccess;
 import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.ev.Toll;
@@ -51,7 +52,8 @@ public class AustriaCountryRule implements CountryRule {
     }
 
     @Override
-    public RoadAccess getAccess(ReaderWay readerWay, TransportationMode transportationMode, RoadAccess currentRoadAccess) {
+    public RoadAccess getAccess(ReaderWay readerWay, TransportationMode transportationMode,
+            RoadAccess currentRoadAccess) {
         if (currentRoadAccess != RoadAccess.YES)
             return currentRoadAccess;
         if (!transportationMode.isMotorVehicle())
@@ -72,7 +74,7 @@ public class AustriaCountryRule implements CountryRule {
                 return RoadAccess.YES;
         }
     }
-    
+
     @Override
     public Toll getToll(ReaderWay readerWay, TransportationMode transportationMode, Toll currentToll) {
         if (!transportationMode.isMotorVehicle() || currentToll != Toll.MISSING) {
@@ -83,7 +85,16 @@ public class AustriaCountryRule implements CountryRule {
         if (roadClass == RoadClass.MOTORWAY || roadClass == RoadClass.TRUNK) {
             return Toll.ALL;
         }
-        
+
         return currentToll;
+    }
+
+    @Override
+    public DrivingSide getDrivingSide(ReaderWay readerWay, DrivingSide currentDrivingSide) {
+        if (currentDrivingSide != DrivingSide.MISSING) {
+            return currentDrivingSide;
+        }
+
+        return DrivingSide.RIGHT;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
@@ -52,8 +52,7 @@ public class AustriaCountryRule implements CountryRule {
     }
 
     @Override
-    public RoadAccess getAccess(ReaderWay readerWay, TransportationMode transportationMode,
-            RoadAccess currentRoadAccess) {
+    public RoadAccess getAccess(ReaderWay readerWay, TransportationMode transportationMode, RoadAccess currentRoadAccess) {
         if (currentRoadAccess != RoadAccess.YES)
             return currentRoadAccess;
         if (!transportationMode.isMotorVehicle())

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRule.java
@@ -19,6 +19,7 @@
 package com.graphhopper.routing.util.countryrules;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.DrivingSide;
 import com.graphhopper.routing.ev.RoadAccess;
 import com.graphhopper.routing.ev.Toll;
 import com.graphhopper.routing.util.TransportationMode;
@@ -37,5 +38,9 @@ public interface CountryRule {
     
     default Toll getToll(ReaderWay readerWay, TransportationMode transportationMode, Toll currentToll) {
         return currentToll;
+    }
+
+    default DrivingSide getDrivingSide(ReaderWay readerWay, DrivingSide currentDrivingSide) {
+        return currentDrivingSide;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRuleFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRuleFactory.java
@@ -33,6 +33,7 @@ public class CountryRuleFactory {
     public CountryRuleFactory() {
         rules.put(AUT, new AustriaCountryRule());
         rules.put(DEU, new GermanyCountryRule());
+        rules.put(USA, new UnitedStatesCountryRule());
     }
 
     public CountryRule getCountryRule(Country country) {

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/GermanyCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/GermanyCountryRule.java
@@ -19,6 +19,7 @@
 package com.graphhopper.routing.util.countryrules;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.DrivingSide;
 import com.graphhopper.routing.ev.MaxSpeed;
 import com.graphhopper.routing.ev.RoadAccess;
 import com.graphhopper.routing.ev.RoadClass;
@@ -31,7 +32,8 @@ import com.graphhopper.routing.util.TransportationMode;
 public class GermanyCountryRule implements CountryRule {
 
     /**
-     * In Germany there are roads without a speed limit. For these roads, this method
+     * In Germany there are roads without a speed limit. For these roads, this
+     * method
      * will return {@link MaxSpeed#UNLIMITED_SIGN_SPEED}.
      * <p>
      * Your implementation should be able to handle these cases.
@@ -42,7 +44,8 @@ public class GermanyCountryRule implements CountryRule {
             return currentMaxSpeed;
 
         RoadClass roadClass = RoadClass.find(readerWay.getTag("highway", ""));
-        // As defined in: https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Maxspeed#Motorcar
+        // As defined in:
+        // https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Maxspeed#Motorcar
         switch (roadClass) {
             case MOTORWAY:
             case TRUNK:
@@ -61,7 +64,8 @@ public class GermanyCountryRule implements CountryRule {
     }
 
     @Override
-    public RoadAccess getAccess(ReaderWay readerWay, TransportationMode transportationMode, RoadAccess currentRoadAccess) {
+    public RoadAccess getAccess(ReaderWay readerWay, TransportationMode transportationMode,
+            RoadAccess currentRoadAccess) {
         if (currentRoadAccess != RoadAccess.YES)
             return currentRoadAccess;
         if (!transportationMode.isMotorVehicle())
@@ -80,18 +84,27 @@ public class GermanyCountryRule implements CountryRule {
                 return RoadAccess.YES;
         }
     }
-    
+
     @Override
     public Toll getToll(ReaderWay readerWay, TransportationMode transportationMode, Toll currentToll) {
         if (!transportationMode.isMotorVehicle() || currentToll != Toll.MISSING) {
             return currentToll;
         }
-        
+
         RoadClass roadClass = RoadClass.find(readerWay.getTag("highway", ""));
         if (roadClass == RoadClass.MOTORWAY || roadClass == RoadClass.TRUNK || roadClass == RoadClass.PRIMARY) {
             return Toll.HGV;
         }
-        
+
         return currentToll;
+    }
+
+    @Override
+    public DrivingSide getDrivingSide(ReaderWay readerWay, DrivingSide currentDrivingSide) {
+        if (currentDrivingSide != DrivingSide.MISSING) {
+            return currentDrivingSide;
+        }
+
+        return DrivingSide.RIGHT;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/GermanyCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/GermanyCountryRule.java
@@ -32,8 +32,7 @@ import com.graphhopper.routing.util.TransportationMode;
 public class GermanyCountryRule implements CountryRule {
 
     /**
-     * In Germany there are roads without a speed limit. For these roads, this
-     * method
+     * In Germany there are roads without a speed limit. For these roads, this method
      * will return {@link MaxSpeed#UNLIMITED_SIGN_SPEED}.
      * <p>
      * Your implementation should be able to handle these cases.
@@ -44,8 +43,7 @@ public class GermanyCountryRule implements CountryRule {
             return currentMaxSpeed;
 
         RoadClass roadClass = RoadClass.find(readerWay.getTag("highway", ""));
-        // As defined in:
-        // https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Maxspeed#Motorcar
+        // As defined in: https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Maxspeed#Motorcar
         switch (roadClass) {
             case MOTORWAY:
             case TRUNK:
@@ -64,8 +62,7 @@ public class GermanyCountryRule implements CountryRule {
     }
 
     @Override
-    public RoadAccess getAccess(ReaderWay readerWay, TransportationMode transportationMode,
-            RoadAccess currentRoadAccess) {
+    public RoadAccess getAccess(ReaderWay readerWay, TransportationMode transportationMode, RoadAccess currentRoadAccess) {
         if (currentRoadAccess != RoadAccess.YES)
             return currentRoadAccess;
         if (!transportationMode.isMotorVehicle())

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/UnitedStatesCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/UnitedStatesCountryRule.java
@@ -1,0 +1,16 @@
+package com.graphhopper.routing.util.countryrules;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.DrivingSide;
+
+public class UnitedStatesCountryRule implements CountryRule {
+  
+  @Override
+  public DrivingSide getDrivingSide(ReaderWay readerWay, DrivingSide currentDrivingSide) {
+    if (currentDrivingSide != DrivingSide.MISSING) {
+      return currentDrivingSide;
+    }
+
+    return DrivingSide.RIGHT;
+  }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
@@ -68,11 +68,15 @@ public class OSMCyclewayParser implements TagParser {
       }
     }
 
+    if (readerWay.getId() == 986752740) {
+      System.out.println(readerWay);
+    }
+
     return edgeFlags;
   }
 
   protected boolean isOneway(ReaderWay way) {
-    return way.hasTag("oneway")
+    return way.hasTag("oneway", oneways)
         || way.hasTag("oneway:bicycle", oneways)
         || way.hasTag("cycleway:left:oneway", oneways)
         || way.hasTag("cycleway:right:oneway", oneways)

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
@@ -8,18 +8,34 @@ import com.graphhopper.routing.ev.Cycleway;
 import com.graphhopper.storage.IntsRef;
 
 import java.util.List;
+import java.util.Set;
 import java.util.Arrays;
+import java.util.HashSet;
 
 public class OSMCyclewayParser implements TagParser {
 
   private final EnumEncodedValue<Cycleway> cyclewayEnc;
+  private final Set<String> oneways = new HashSet<>(5);
+  protected final Set<String> restrictedValues = new HashSet<>(5);
 
   public OSMCyclewayParser() {
-    this(new EnumEncodedValue<>(Cycleway.KEY, Cycleway.class));
+    this(new EnumEncodedValue<>(Cycleway.KEY, Cycleway.class, true));
   }
 
   public OSMCyclewayParser(EnumEncodedValue<Cycleway> cyclewayEnc) {
     this.cyclewayEnc = cyclewayEnc;
+    oneways.add("yes");
+    oneways.add("true");
+    oneways.add("1");
+    oneways.add("-1");
+    restrictedValues.add("agricultural");
+    restrictedValues.add("forestry");
+    restrictedValues.add("no");
+    restrictedValues.add("restricted");
+    restrictedValues.add("delivery");
+    restrictedValues.add("military");
+    restrictedValues.add("emergency");
+    restrictedValues.add("private");
   }
 
   @Override
@@ -30,12 +46,39 @@ public class OSMCyclewayParser implements TagParser {
   @Override
   public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
     String cyclewayTag = readerWay
-        .getFirstPriorityTag(Arrays.asList("cycleway", "cycleway:both", "cycleway:left", "cycleway:right"));
+        .getFirstPriorityTag(Arrays.asList("cycleway", "cycleway:both"));
     Cycleway cycleway = Cycleway.find(cyclewayTag);
-    if (cycleway == Cycleway.MISSING)
-      return edgeFlags;
+    Cycleway cyclewayRight = Cycleway.find(readerWay.getTag("cycleway:right"));
+    Cycleway cyclewayLeft = Cycleway.find(readerWay.getTag("cycleway:left"));
 
-    cyclewayEnc.setEnum(false, edgeFlags, cycleway);
+    if (cycleway != Cycleway.MISSING) {
+      cyclewayEnc.setEnum(false, edgeFlags, cycleway);
+      cyclewayEnc.setEnum(true, edgeFlags, cycleway);
+    }
+    if (cyclewayRight != Cycleway.MISSING) {
+      cyclewayEnc.setEnum(false, edgeFlags, cyclewayRight);
+      if (isOneway(readerWay)) {
+        cyclewayEnc.setEnum(true, edgeFlags, cyclewayRight);
+      }
+    }
+    if (cyclewayLeft != Cycleway.MISSING) {
+      cyclewayEnc.setEnum(true, edgeFlags, cyclewayLeft);
+      if (isOneway(readerWay)) {
+        cyclewayEnc.setEnum(false, edgeFlags, cyclewayLeft);
+      }
+    }
+
     return edgeFlags;
+  }
+
+  protected boolean isOneway(ReaderWay way) {
+    return way.hasTag("oneway")
+        || way.hasTag("oneway:bicycle", oneways)
+        || way.hasTag("cycleway:left:oneway", oneways)
+        || way.hasTag("cycleway:right:oneway", oneways)
+        || way.hasTag("vehicle:backward", restrictedValues)
+        || way.hasTag("vehicle:forward", restrictedValues)
+        || way.hasTag("bicycle:backward", restrictedValues)
+        || way.hasTag("bicycle:forward", restrictedValues);
   }
 }


### PR DESCRIPTION
This closes #26 by correctly parsing left/right cycleways differently depending on the direction of the road, and the driving_side of the country we're routing in.

![image](https://user-images.githubusercontent.com/2773087/158897314-f11ed2e9-9ef4-4f82-881a-fd7ec09176e8.png)

![image](https://user-images.githubusercontent.com/2773087/158897489-140c759c-66fc-40fe-9b21-c3b40b3417d5.png)
