### PR TITLE
Bumping version number to be M1 compatible

### DIFF
--- a/web-bundle/pom.xml
+++ b/web-bundle/pom.xml
@@ -128,7 +128,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.10.0</version>
+                <version>1.11.0</version>
                 <executions>
                     <execution>
                         <id>install node and npm</id>


### PR DESCRIPTION
Graphhopper currrently fails to build on M1 macs, on the com.github.eirslett:frontend-maven-plugin:1.11.0:install-node-and-npm target. Background: https://github.com/eirslett/frontend-maven-plugin/issues/952, tldr; M1 requires a higher version number 