### PR TITLE
Add PenaltyWeighting

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/DefaultWeightingFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/DefaultWeightingFactory.java
@@ -83,7 +83,9 @@ public class DefaultWeightingFactory implements WeightingFactory {
         } else if ("shortest".equalsIgnoreCase(weightingStr)) {
             weighting = new ShortestWeighting(encoder, turnCostProvider);
         } else if ("fastest".equalsIgnoreCase(weightingStr)) {
-            if (encoder.supports(PriorityWeighting.class))
+            if (encoder.supports(PenaltyWeighting.class))
+                weighting = new PenaltyWeighting(encoder, hints, turnCostProvider);
+            else if (encoder.supports(PriorityWeighting.class))
                 weighting = new PriorityWeighting(encoder, hints, turnCostProvider);
             else
                 weighting = new FastestWeighting(encoder, hints, turnCostProvider);

--- a/core/src/main/java/com/graphhopper/routing/util/PenaltyCode.java
+++ b/core/src/main/java/com/graphhopper/routing/util/PenaltyCode.java
@@ -1,0 +1,57 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util;
+
+/**
+ * Used to store a penalty value in the way flags of an edge. Used in
+ * combination with PenaltyWeighting
+ *
+ * @author Hazel Court
+ */
+public enum PenaltyCode {
+    EXCLUDE(511),
+    REACH_DESTINATION(15),
+    VERY_BAD(13),
+    BAD(12),
+    AVOID_MORE(11),
+    AVOID(10),
+    SLIGHT_AVOID(9),
+    UNCHANGED(8),
+    SLIGHT_PREFER(6),
+    PREFER(5),
+    VERY_NICE(3),
+    BEST(1);
+
+    private final int value;
+
+    PenaltyCode(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static double getFactor(int value) {
+        return (double) value / 10.0;
+    }
+
+    public static double getValue(int value) {
+        return getFactor(value);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/PenaltyCode.java
+++ b/core/src/main/java/com/graphhopper/routing/util/PenaltyCode.java
@@ -48,7 +48,7 @@ public enum PenaltyCode {
     }
 
     public static double getFactor(int value) {
-        return (double) value / 10.0;
+        return (double) value;
     }
 
     public static double getValue(int value) {

--- a/core/src/main/java/com/graphhopper/routing/weighting/PenaltyWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/PenaltyWeighting.java
@@ -40,7 +40,7 @@ public class PenaltyWeighting extends FastestWeighting {
     public PenaltyWeighting(FlagEncoder encoder, PMap pMap, TurnCostProvider turnCostProvider) {
         super(encoder, pMap, turnCostProvider);
         penaltyEnc = encoder.getDecimalEncodedValue(EncodingManager.getKey(encoder, "penalty"));
-        minFactor = 1 / PenaltyCode.getValue(EXCLUDE.getValue());
+        minFactor = 1;
         maxPenalty = PenaltyCode.getFactor(EXCLUDE.getValue());
     }
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/PenaltyWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/PenaltyWeighting.java
@@ -1,0 +1,63 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.weighting;
+
+import com.graphhopper.routing.ev.DecimalEncodedValue;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.util.PenaltyCode;
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.PMap;
+
+import static com.graphhopper.routing.util.PenaltyCode.EXCLUDE;
+
+/**
+ * Special weighting for (motor)bike, flipped version of PriorityWeighting
+ *
+ * @author Hazel Court
+ */
+public class PenaltyWeighting extends FastestWeighting {
+
+    private final double minFactor;
+    private final double maxPenalty;
+    private final DecimalEncodedValue penaltyEnc;
+
+    public PenaltyWeighting(FlagEncoder encoder, PMap pMap, TurnCostProvider turnCostProvider) {
+        super(encoder, pMap, turnCostProvider);
+        penaltyEnc = encoder.getDecimalEncodedValue(EncodingManager.getKey(encoder, "penalty"));
+        minFactor = 1 / PenaltyCode.getValue(EXCLUDE.getValue());
+        maxPenalty = PenaltyCode.getFactor(EXCLUDE.getValue());
+    }
+
+    @Override
+    public double getMinWeight(double distance) {
+        return minFactor * super.getMinWeight(distance);
+    }
+
+    @Override
+    public double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
+        double weight = super.calcEdgeWeight(edgeState, reverse);
+        if (Double.isInfinite(weight))
+            return Double.POSITIVE_INFINITY;
+        double penalty = edgeState.get(penaltyEnc);
+        if (penalty > maxPenalty)
+            throw new IllegalArgumentException("penalty cannot be bigger than " + maxPenalty + " but was " + penalty);
+
+        return weight * penalty;
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/TagParserManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/TagParserManagerTest.java
@@ -69,7 +69,7 @@ class TagParserManagerTest {
             @Override
             public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way) {
                 if (bikeRouteEnc.getEnum(false, edgeFlags) != RouteNetwork.MISSING)
-                    priorityEnc.setDecimal(false, edgeFlags, PriorityCode.getFactor(2));
+                    penaltyEnc.setDecimal(false, edgeFlags, PriorityCode.getFactor(2));
                 return edgeFlags;
             }
         };
@@ -81,8 +81,8 @@ class TagParserManagerTest {
         IntsRef relFlags = manager.handleRelationTags(osmRel, manager.createRelationFlags());
         IntsRef edgeFlags = manager.handleWayTags(osmWay, relFlags);
 
-        assertTrue(defaultBike.priorityEnc.getDecimal(false, edgeFlags)
-                > lessRelationCodes.priorityEnc.getDecimal(false, edgeFlags));
+        assertTrue(defaultBike.penaltyEnc.getDecimal(false, edgeFlags) > lessRelationCodes.penaltyEnc.getDecimal(false,
+                edgeFlags));
     }
 
     @Test
@@ -105,8 +105,8 @@ class TagParserManagerTest {
 
         // bike: uninfluenced speed for grade but via network => NICE
         // mtb: uninfluenced speed only PREFER
-        assertTrue(bikeEncoder.priorityEnc.getDecimal(false, edgeFlags)
-                > mtbEncoder.priorityEnc.getDecimal(false, edgeFlags));
+        assertTrue(bikeEncoder.penaltyEnc.getDecimal(false, edgeFlags) > mtbEncoder.penaltyEnc.getDecimal(false,
+                edgeFlags));
     }
 
     @Test


### PR DESCRIPTION
Instead of dividing the edge time (milliseconds) by a priority, multiply the time by a penalty. This way is easier to reason about.

Tested by routing and clicking around to make sure the routes still look sane.