### PR TITLE
Let us bike on pedestrian ways, paths, footways

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -210,9 +210,9 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         highwayMap.put("tertiary", AVOID.getValue());
         highwayMap.put("tertiary_link", AVOID.getValue());
         // Pedestrian ways
+        highwayMap.put("footway", UNCHANGED.getValue());
         highwayMap.put("path", SLIGHT_PREFER.getValue());
-        highwayMap.put("footway", SLIGHT_PREFER.getValue());
-        highwayMap.put("pedestrian", PREFER.getValue());
+        highwayMap.put("pedestrian", VERY_NICE.getValue());
         // Quiet ways
         highwayMap.put("residential", SLIGHT_PREFER.getValue());
         highwayMap.put("service", SLIGHT_PREFER.getValue());

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -150,11 +150,11 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
         final int CYCLEWAY_SPEED = 18;  // Make sure cycleway and path use same speed value, see #634
         setHighwaySpeed("cycleway", CYCLEWAY_SPEED);
-        setHighwaySpeed("path", 14);
+        setHighwaySpeed("path", CYCLEWAY_SPEED);
         setHighwaySpeed("footway", 14);
         setHighwaySpeed("platform", 6);
-        setHighwaySpeed("pedestrian", 14);
-        setHighwaySpeed("track", 18);
+        setHighwaySpeed("pedestrian", CYCLEWAY_SPEED);
+        setHighwaySpeed("track", CYCLEWAY_SPEED);
         setHighwaySpeed("service", 14);
         setHighwaySpeed("residential", 18);
         // no other highway applies:

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -150,7 +150,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
         final int CYCLEWAY_SPEED = 18;  // Make sure cycleway and path use same speed value, see #634
         setHighwaySpeed("cycleway", CYCLEWAY_SPEED);
-        setHighwaySpeed("path", 10);
+        setHighwaySpeed("path", 14);
         setHighwaySpeed("footway", 14);
         setHighwaySpeed("platform", 6);
         setHighwaySpeed("pedestrian", 14);
@@ -210,9 +210,9 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         highwayMap.put("tertiary", AVOID.getValue());
         highwayMap.put("tertiary_link", AVOID.getValue());
         // Pedestrian ways
-        highwayMap.put("footway", SLIGHT_AVOID.getValue());
-        highwayMap.put("pedestrian", SLIGHT_AVOID.getValue());
-        highwayMap.put("path", SLIGHT_AVOID.getValue());
+        highwayMap.put("path", SLIGHT_PREFER.getValue());
+        highwayMap.put("footway", SLIGHT_PREFER.getValue());
+        highwayMap.put("pedestrian", PREFER.getValue());
         // Quiet ways
         highwayMap.put("residential", SLIGHT_PREFER.getValue());
         highwayMap.put("service", SLIGHT_PREFER.getValue());
@@ -518,10 +518,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
         // Associate penalty with cycle infrastructure
         if (way.hasTag("bicycle", "designated", "official")) {
-            if ("path".equals(highway))
-                penaltyMap.put(CYCLE_INFRA_KEY, VERY_NICE.getValue());
-            else
-                penaltyMap.put(CYCLE_INFRA_KEY, PREFER.getValue());
+            penaltyMap.put(CYCLE_INFRA_KEY, VERY_NICE.getValue());
         }
         if (way.hasTag("bicycle", "use_sidepath")) {
             penaltyMap.put(CYCLE_INFRA_KEY, REACH_DESTINATION.getValue());

--- a/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
@@ -51,9 +51,7 @@ public class BikeFlagEncoder extends BikeCommonFlagEncoder {
 
     public BikeFlagEncoder(String name, int speedBits, double speedFactor, int maxTurnCosts, boolean speedTwoDirections) {
         super(name, speedBits, speedFactor, maxTurnCosts, speedTwoDirections);
-        addPushingSection("path");
         addPushingSection("footway");
-        addPushingSection("pedestrian");
         addPushingSection("steps");
         addPushingSection("platform");
 


### PR DESCRIPTION
Trying to reflect the realities of how these ways are tagged, I tried to:
- treat [pedestrian](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dpedestrian) ways as shut-down streets like JFK promenade. They are wider than cycleways and paths. We definitely also don't need to push our bikes on them!
- treat [paths](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dpath) as mixed-use thin ways. Prefer them a bit less. Still don't need to push a bike.
- treat [footways](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dfootway) as pedestrian-preferred thin ways. Prefer them least of these three. Set speed a little slower since pedestrians are also there.  Probably need to push our bikes, unless bicycle=yes or designated. Open to considering that these are bikes allowed by default, but as an example most separately-mapped [sidewalks](https://wiki.openstreetmap.org/wiki/Sidewalks) are tagged as footways, likely without bicycle=no.


Specifically made this to fix this issue
![image](https://user-images.githubusercontent.com/2773087/167179302-044bb3d7-a7f2-42c7-ac47-f45410ddc8b5.png)
