### PR TITLE
Do not set response path time to the wrong thing

### DIFF
--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/PtRouterImpl.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/PtRouterImpl.java
@@ -189,7 +189,6 @@ public final class PtRouterImpl implements PtRouter {
             for (List<Label.Transition> solution : solutions) {
                 final ResponsePath responsePath = tripFromLabel.createResponsePath(translation, waypoints, router, queryGraph, connectingWeighting, solution, requestedPathDetails, connectingProfile.getVehicle(), includeElevation);
                 responsePath.setImpossible(solution.stream().anyMatch(t -> t.label.impossible));
-                responsePath.setTime((solution.get(solution.size() - 1).label.currentTime - solution.get(0).label.currentTime));
                 responsePath.setRouteWeight(router.weight(solution.get(solution.size() - 1).label));
                 response.add(responsePath);
             }


### PR DESCRIPTION
ResponsePaths are already having `time` set to the duration of the trip, so don't setTime to the time from now. This results in the results being correctly sorted as well.

Before:

![image](https://user-images.githubusercontent.com/2773087/168937403-e3fd25e0-e1d2-4dbd-be59-c534b09ae172.png)

After:

![image](https://user-images.githubusercontent.com/2773087/168937598-9df12d71-6544-40ce-864d-7fe2d9fe5c11.png)
