### PR TITLE
Make bike router ignore ferries, configurably

### DIFF
--- a/bay-area/config-local.yml
+++ b/bay-area/config-local.yml
@@ -51,9 +51,11 @@ graphhopper:
     - name: bike2
       vehicle: bike2
       weighting: fastest
+      use_ferries: false
     - name: foot
       vehicle: foot
       weighting: fastest
+      use_ferries: false
 
   #  - name: car_with_turn_costs
   #    vehicle: car

--- a/bay-area/config.yml
+++ b/bay-area/config.yml
@@ -53,10 +53,12 @@ graphhopper:
       vehicle: bike2
       weighting: fastest
       turn_costs: true
-      u_turn_costs: 10
+      u_turn_costs: 
+      use_ferries: false
     - name: foot
       vehicle: foot
       weighting: fastest
+      use_ferries: false
 
   #  - name: car_with_turn_costs
   #    vehicle: car

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -347,12 +347,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
                 avgSpeedEnc.setDecimal(true, edgeFlags, wayTypeSpeed);
             handleAccess(edgeFlags, way);
         } else {
-            double ferrySpeed = ferrySpeedCalc.getSpeed(way);
-            avgSpeedEnc.setDecimal(false, edgeFlags, ferrySpeed);
-            if (avgSpeedEnc.isStoreTwoDirections())
-                avgSpeedEnc.setDecimal(true, edgeFlags, ferrySpeed);
-            accessEnc.setBool(false, edgeFlags, true);
-            accessEnc.setBool(true, edgeFlags, true);
+            handleFerrySpeedAndAccess(edgeFlags, way);
         }
 
         handlePenalty(edgeFlags, way, wayTypeSpeed);
@@ -419,6 +414,16 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             }
         }
         return speed;
+    }
+
+    void handleFerrySpeedAndAccess(IntsRef edgeFlags, ReaderWay way) {
+        double ferrySpeed = ferrySpeedCalc.getSpeed(way);
+        avgSpeedEnc.setDecimal(false, edgeFlags, ferrySpeed);
+        if (avgSpeedEnc.isStoreTwoDirections())
+            avgSpeedEnc.setDecimal(true, edgeFlags, ferrySpeed);
+        // Figure out hours, then...
+        accessEnc.setBool(false, edgeFlags, false);
+        accessEnc.setBool(true, edgeFlags, false);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -56,6 +56,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     private final Map<String, Integer> highwaySpeeds = new HashMap<>();
     protected final boolean penaltyTwoDirections = true;
     protected boolean speedTwoDirections;
+    protected boolean useFerries;
     protected final DecimalEncodedValue penaltyEnc;
     // Car speed limit which switches the preference from UNCHANGED to AVOID_IF_POSSIBLE
     private int avoidSpeedLimit;
@@ -68,7 +69,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     // This is the specific bicycle class
     private String classBicycleKey;
 
-    protected BikeCommonFlagEncoder(String name, int speedBits, double speedFactor, int maxTurnCosts, boolean speedTwoDirections) {
+    protected BikeCommonFlagEncoder(String name, int speedBits, double speedFactor, int maxTurnCosts,
+            boolean speedTwoDirections, boolean useFerries) {
         super(name, speedBits, speedFactor, speedTwoDirections, maxTurnCosts);
 
         penaltyEnc = new DecimalEncodedValueImpl(getKey(name, "penalty"), 4, PenaltyCode.getFactor(1),
@@ -421,9 +423,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         avgSpeedEnc.setDecimal(false, edgeFlags, ferrySpeed);
         if (avgSpeedEnc.isStoreTwoDirections())
             avgSpeedEnc.setDecimal(true, edgeFlags, ferrySpeed);
-        // Figure out hours, then...
-        accessEnc.setBool(false, edgeFlags, false);
-        accessEnc.setBool(true, edgeFlags, false);
+        accessEnc.setBool(false, edgeFlags, useFerries);
+        accessEnc.setBool(true, edgeFlags, useFerries);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
@@ -31,7 +31,7 @@ public class BikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     public BikeFlagEncoder(String name) {
-        this(name, 4, 2, 0, false);
+        this(name, 4, 2, 0, false, true);
     }
 
     public BikeFlagEncoder(PMap properties) {
@@ -39,18 +39,20 @@ public class BikeFlagEncoder extends BikeCommonFlagEncoder {
                 properties.getInt("speed_bits", 4),
                 properties.getInt("speed_factor", 2),
                 properties.getBool("turn_costs", false) ? 1 : 0,
-                properties.getBool("speed_two_directions", false));
+                properties.getBool("speed_two_directions", false), properties.getBool("use_ferries", true));
 
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));
     }
 
-    public BikeFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts, boolean speedTwoDirections) {
-        this("bike", speedBits, speedFactor, maxTurnCosts, speedTwoDirections);
+    public BikeFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts, boolean speedTwoDirections,
+            boolean useFerries) {
+        this("bike", speedBits, speedFactor, maxTurnCosts, speedTwoDirections, useFerries);
     }
 
-    public BikeFlagEncoder(String name, int speedBits, double speedFactor, int maxTurnCosts, boolean speedTwoDirections) {
-        super(name, speedBits, speedFactor, maxTurnCosts, speedTwoDirections);
+    public BikeFlagEncoder(String name, int speedBits, double speedFactor, int maxTurnCosts, boolean speedTwoDirections,
+            boolean useFerries) {
+        super(name, speedBits, speedFactor, maxTurnCosts, speedTwoDirections, useFerries);
         addPushingSection("footway");
         addPushingSection("steps");
         addPushingSection("platform");

--- a/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
@@ -33,20 +33,20 @@ import static com.graphhopper.routing.util.PenaltyCode.*;
  */
 public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
     public MountainBikeFlagEncoder() {
-        this(4, 2, 0);
+        this(4, 2, 0, true);
     }
 
     public MountainBikeFlagEncoder(PMap properties) {
         this(properties.getInt("speed_bits", 4),
                 properties.getDouble("speed_factor", 2),
-                properties.getBool("turn_costs", false) ? 1 : 0);
+                properties.getBool("turn_costs", false) ? 1 : 0, properties.getBool("use_ferries", true));
 
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));
     }
 
-    protected MountainBikeFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts) {
-        super("mtb", speedBits, speedFactor, maxTurnCosts, false);
+    protected MountainBikeFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts, boolean useFerries) {
+        super("mtb", speedBits, speedFactor, maxTurnCosts, false, useFerries);
         setTrackTypeSpeed("grade1", 18); // paved
         setTrackTypeSpeed("grade2", 16); // now unpaved ...
         setTrackTypeSpeed("grade3", 12);

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -32,20 +32,20 @@ import static com.graphhopper.routing.util.PenaltyCode.*;
  */
 public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
     public RacingBikeFlagEncoder() {
-        this(4, 2, 0);
+        this(4, 2, 0, true);
     }
 
     public RacingBikeFlagEncoder(PMap properties) {
         this(properties.getInt("speed_bits", 4),
                 properties.getDouble("speed_factor", 2),
-                properties.getBool("turn_costs", false) ? 1 : 0);
+                properties.getBool("turn_costs", false) ? 1 : 0, properties.getBool("use_ferries", true));
 
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));
     }
 
-    protected RacingBikeFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts) {
-        super("racingbike", speedBits, speedFactor, maxTurnCosts, false);
+    protected RacingBikeFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts, boolean useFerries) {
+        super("racingbike", speedBits, speedFactor, maxTurnCosts, false, useFerries);
         preferHighwayTags.add("road");
         preferHighwayTags.add("secondary");
         preferHighwayTags.add("secondary_link");

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -668,7 +668,7 @@ public class OSMReaderTest {
                 return TransportationMode.HGV;
             }
         };
-        BikeFlagEncoder bike = new BikeFlagEncoder(4, 2, 24, false);
+        BikeFlagEncoder bike = new BikeFlagEncoder(4, 2, 24, false, true);
 
         GraphHopper hopper = new GraphHopper();
         hopper.getTagParserManagerBuilder().add(bike).add(truck).add(car);
@@ -980,7 +980,7 @@ public class OSMReaderTest {
             BikeFlagEncoder bikeEncoder;
             if (turnCosts) {
                 carEncoder = new CarFlagEncoder(5, 5, 1);
-                bikeEncoder = new BikeFlagEncoder(4, 2, 1, false);
+                bikeEncoder = new BikeFlagEncoder(4, 2, 1, false, true);
             } else {
                 carEncoder = new CarFlagEncoder();
                 bikeEncoder = new BikeFlagEncoder();

--- a/core/src/test/java/com/graphhopper/storage/TurnCostStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/TurnCostStorageTest.java
@@ -44,7 +44,7 @@ public class TurnCostStorageTest {
     @BeforeEach
     public void setup() {
         CarFlagEncoder carEncoder = new CarFlagEncoder(5, 5, 3);
-        BikeFlagEncoder bikeEncoder = new BikeFlagEncoder(5, 5, 3, false);
+        BikeFlagEncoder bikeEncoder = new BikeFlagEncoder(5, 5, 3, false, true);
         manager = EncodingManager.create(carEncoder, bikeEncoder);
     }
 


### PR DESCRIPTION
Fixes an issue where we get recommended a ferry with very specific hours.
![image](https://user-images.githubusercontent.com/2773087/172065460-e3aab1c0-807f-4312-bb6f-be891edfd4e5.png)

We can get ferries to show up in the public transit routing instead, so ignore ferries at the bike router level.

![image](https://user-images.githubusercontent.com/2773087/172065438-6bc18176-f83f-469a-85cd-019080943506.png)
