### PR TITLE
Add ascend/descend to PT response paths and legs

### DIFF
--- a/web-api/src/main/java/com/graphhopper/Trip.java
+++ b/web-api/src/main/java/com/graphhopper/Trip.java
@@ -81,13 +81,19 @@ public class Trip {
         public final Map<String, List<PathDetail>> details;
         private final Date departureTime;
         private final Date arrivalTime;
+        public final double ascend;
+        public final double descend;
 
-        public ConnectingLeg(String type, String departureLocation, Date departureTime, Geometry geometry, double distance, double weight, InstructionList instructions, Map<String, List<PathDetail>> details, Date arrivalTime) {
+        public ConnectingLeg(String type, String departureLocation, Date departureTime, Geometry geometry,
+                double distance, double weight, InstructionList instructions, Map<String, List<PathDetail>> details,
+                Date arrivalTime, double ascend, double descend) {
             super(type, departureLocation, geometry, distance, weight);
             this.instructions = instructions;
             this.departureTime = departureTime;
             this.details = details;
             this.arrivalTime = arrivalTime;
+            this.ascend = ascend;
+            this.descend = descend;
         }
 
         @Override


### PR DESCRIPTION
Follow up of #90 , also return ascend/descend doubles in PT responses for both paths and non-PT legs.

![image](https://user-images.githubusercontent.com/2773087/183227214-4489a3a0-b78e-4e26-82cf-2d1cc653439d.png)
