### PR TITLE
Fixes for contraflow lanes & fwd/bkwd bike infra parsing

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -91,6 +91,9 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         intendedValues.add("official");
         intendedValues.add("permissive");
 
+        // Now discouraged, cycleway=opposite_* tags mean a one-way road has some sort of
+        // accommodation for bicycles in the reverse direction. See:
+        // https://wiki.openstreetmap.org/wiki/Key:cycleway#Problems_with_opposite*_values
         oppositeLanes.add("opposite");
         oppositeLanes.add("opposite_lane");
         oppositeLanes.add("opposite_track");
@@ -574,6 +577,9 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         boolean isRoundabout = roundaboutEnc.getBool(false, edgeFlags);
         boolean isOnewayForCars = isRoundabout || way.hasTag("oneway", oneways);
         boolean isBackwardOnewayForCars = way.hasTag("oneway", "-1");
+        // Bike exceptions may include oneway:bicycle=no,
+        // the deprecated cycleway=opposite_* tags,
+        // or a left or right cycleway either backwards (-1) or two-way.
         boolean hasBikeExceptionToOneway = (
             way.hasTag("oneway:bicycle", "no")
             || way.hasTag("cycleway", oppositeLanes)

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
@@ -84,7 +84,7 @@ public class OSMCyclewayParser implements TagParser {
             String cyclewayLeftOnewayTag = readerWay.getTag("cycleway:left:oneway", "");
             boolean cyclewayLeftTwoway = cyclewayLeftOnewayTag.equals("no");
             boolean cyclewayLeftBackward = cyclewayLeftOnewayTag.equals("-1") || (
-                cyclewayLeftOnewayTag == "" && drivingSide == DrivingSide.RIGHT
+                cyclewayLeftOnewayTag.equals("") && drivingSide == DrivingSide.RIGHT
                 && !isOnewayForCars
             );
             if (cyclewayLeftTwoway || cyclewayLeftBackward)
@@ -97,7 +97,7 @@ public class OSMCyclewayParser implements TagParser {
             String cyclewayRightOnewayTag = readerWay.getTag("cycleway:right:oneway", "");
             boolean cyclewayRightTwoway = cyclewayRightOnewayTag.equals("no");
             boolean cyclewayRightBackward = cyclewayRightOnewayTag.equals("-1") || (
-                cyclewayRightOnewayTag == "" && drivingSide == DrivingSide.LEFT
+                cyclewayRightOnewayTag.equals("") && drivingSide == DrivingSide.LEFT
                 && !isOnewayForCars
             );
             if (cyclewayRightTwoway || cyclewayRightBackward)

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
@@ -13,81 +13,122 @@ import java.util.List;
 import java.util.Set;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.HashMap;
 
 public class OSMCyclewayParser implements TagParser {
 
-  private final EnumEncodedValue<Cycleway> cyclewayEnc;
-  private final Set<String> oneways = new HashSet<>(5);
-  protected final Set<String> restrictedValues = new HashSet<>(5);
+    private final EnumEncodedValue<Cycleway> cyclewayEnc;
+    private final Set<String> oneways = new HashSet<>(5);
+    protected final HashMap<String, Cycleway> oppositeLanes = new HashMap<>();
 
-  public OSMCyclewayParser() {
-    this(new EnumEncodedValue<>(Cycleway.KEY, Cycleway.class, true));
-  }
-
-  public OSMCyclewayParser(EnumEncodedValue<Cycleway> cyclewayEnc) {
-    this.cyclewayEnc = cyclewayEnc;
-    oneways.add("yes");
-    oneways.add("true");
-    oneways.add("1");
-    oneways.add("-1");
-    restrictedValues.add("agricultural");
-    restrictedValues.add("forestry");
-    restrictedValues.add("no");
-    restrictedValues.add("restricted");
-    restrictedValues.add("delivery");
-    restrictedValues.add("military");
-    restrictedValues.add("emergency");
-    restrictedValues.add("private");
-  }
-
-  @Override
-  public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
-    list.add(cyclewayEnc);
-  }
-
-  @Override
-  public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
-    String cyclewayTag = readerWay
-        .getFirstPriorityTag(Arrays.asList("cycleway", "cycleway:both"));
-    Cycleway cycleway = Cycleway.find(cyclewayTag);
-    
-    // Determine the forward cycleway side from country rules
-    DrivingSide drivingSide = DrivingSide.find(readerWay.getTag("driving_side"));
-    CountryRule countryRule = readerWay.getTag("country_rule", null);
-    if (countryRule != null) {
-        drivingSide = countryRule.getDrivingSide(readerWay, drivingSide);
-    }
-    Cycleway cyclewayForward = Cycleway.find(readerWay.getTag("cycleway:" + drivingSide.toString()));
-    Cycleway cyclewayBackward = Cycleway.find(readerWay.getTag("cycleway:" + DrivingSide.reverse(drivingSide).toString()));
-
-    if (cycleway != Cycleway.MISSING) {
-      cyclewayEnc.setEnum(false, edgeFlags, cycleway);
-      cyclewayEnc.setEnum(true, edgeFlags, cycleway);
-    }
-    if (cyclewayForward != Cycleway.MISSING) {
-      cyclewayEnc.setEnum(false, edgeFlags, cyclewayForward);
-      if (isOneway(readerWay)) {
-        cyclewayEnc.setEnum(true, edgeFlags, cyclewayForward);
-      }
-    }
-    if (cyclewayBackward != Cycleway.MISSING) {
-      cyclewayEnc.setEnum(true, edgeFlags, cyclewayBackward);
-      if (isOneway(readerWay)) {
-        cyclewayEnc.setEnum(false, edgeFlags, cyclewayBackward);
-      }
+    public OSMCyclewayParser() {
+        this(new EnumEncodedValue<>(Cycleway.KEY, Cycleway.class, true));
     }
 
-    return edgeFlags;
-  }
+    public OSMCyclewayParser(EnumEncodedValue<Cycleway> cyclewayEnc) {
+        this.cyclewayEnc = cyclewayEnc;
+        oneways.add("yes");
+        oneways.add("true");
+        oneways.add("1");
+        oneways.add("-1");
 
-  protected boolean isOneway(ReaderWay way) {
-    return way.hasTag("oneway", oneways)
-        || way.hasTag("oneway:bicycle", oneways)
-        || way.hasTag("cycleway:left:oneway", oneways)
-        || way.hasTag("cycleway:right:oneway", oneways)
-        || way.hasTag("vehicle:backward", restrictedValues)
-        || way.hasTag("vehicle:forward", restrictedValues)
-        || way.hasTag("bicycle:backward", restrictedValues)
-        || way.hasTag("bicycle:forward", restrictedValues);
-  }
+        oppositeLanes.put("opposite", Cycleway.SHARED_LANE);
+        oppositeLanes.put("opposite_lane", Cycleway.LANE);
+        oppositeLanes.put("opposite_track", Cycleway.TRACK);
+        oppositeLanes.put("opposite_share_busway", Cycleway.SHARE_BUSWAY);
+    }
+
+    @Override
+    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
+        list.add(cyclewayEnc);
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
+        // Figuring out what kind of bike infra applies to the forward and backward direction
+        // is complicated.
+        //
+        // The goal here is, given the cycleway, cycleway:both:*, and cycleway:left/right:* tags
+        // and the driving side, to come up with a notion of forward and backward cycleway values,
+        // normalized not to use the "opposite" values.
+        //
+        // To simplify the number of cases, cycleway:both is treated as a shorthand for setting
+        // both cycleway:left and cycleway:right, instead of being treated as a different case.
+        // Note that this is different from how the cyclewag tag is treated (see
+        // https://wiki.openstreetmap.org/wiki/Key:cycleway:both).
+
+        Cycleway cycleway = Cycleway.find(readerWay.getTag("cycleway"));
+
+        // Default forward and backward to the "cycleway" value until we find a more
+        // specific value.
+        Cycleway cyclewayForward = cycleway, cyclewayBackward = cycleway;
+
+        // If we find opposite_* tags, normalize them, and treat that as the final word
+        // (discounting any contradictory left/right tags which would be a tagging error).
+        if (oppositeLanes.containsKey(cycleway)) {
+            cyclewayForward = Cycleway.SHARED_LANE;
+            cyclewayBackward = oppositeLanes.get(cycleway);
+        } else {
+            // Driving side is needed to compute default directionality of cycleway:left/right.
+            // See defaults described in wiki:
+            // https://wiki.openstreetmap.org/wiki/Key:cycleway:right:oneway
+            DrivingSide drivingSide = DrivingSide.find(readerWay.getTag("driving_side"));
+            CountryRule countryRule = readerWay.getTag("country_rule", null);
+            if (countryRule != null) {
+                drivingSide = countryRule.getDrivingSide(readerWay, drivingSide);
+            }
+            boolean isOnewayForCars = readerWay.hasTag("oneway", oneways);
+
+            Cycleway cyclewayLeft = Cycleway.find(
+                readerWay.getFirstPriorityTag(Arrays.asList("cycleway:left", "cycleway:both")));
+            String cyclewayLeftOnewayTag = readerWay.getTag("cycleway:left:oneway", "");
+            boolean cyclewayLeftTwoway = cyclewayLeftOnewayTag.equals("no");
+            boolean cyclewayLeftBackward = cyclewayLeftOnewayTag.equals("-1") || (
+                cyclewayLeftOnewayTag == "" && drivingSide == DrivingSide.RIGHT
+                && !isOnewayForCars
+            );
+            if (cyclewayLeftTwoway || cyclewayLeftBackward)
+                cyclewayBackward = mergeCyclewayValues(cyclewayBackward, cyclewayLeft);
+            if (cyclewayLeftTwoway || !cyclewayLeftBackward)
+                cyclewayForward = mergeCyclewayValues(cyclewayForward, cyclewayLeft);
+
+            Cycleway cyclewayRight = Cycleway.find(
+                readerWay.getFirstPriorityTag(Arrays.asList("cycleway:right", "cycleway:both")));
+            String cyclewayRightOnewayTag = readerWay.getTag("cycleway:right:oneway", "");
+            boolean cyclewayRightTwoway = cyclewayRightOnewayTag.equals("no");
+            boolean cyclewayRightBackward = cyclewayRightOnewayTag.equals("-1") || (
+                cyclewayRightOnewayTag == "" && drivingSide == DrivingSide.LEFT
+                && !isOnewayForCars
+            );
+            if (cyclewayRightTwoway || cyclewayRightBackward)
+                cyclewayBackward = mergeCyclewayValues(cyclewayBackward, cyclewayRight);
+            if (cyclewayRightTwoway || !cyclewayRightBackward)
+                cyclewayForward = mergeCyclewayValues(cyclewayForward, cyclewayRight);
+        }
+
+        if (cyclewayForward != Cycleway.MISSING)
+            cyclewayEnc.setEnum(false, edgeFlags, cyclewayForward);
+        if (cyclewayBackward != Cycleway.MISSING)
+            cyclewayEnc.setEnum(true, edgeFlags, cyclewayBackward);
+
+        return edgeFlags;
+    }
+
+    private Cycleway mergeCyclewayValues(Cycleway first, Cycleway second) {
+        // Merge two cycleway values by the following rules:
+        // NO takes precedence over MISSING
+        // Any affirmative value takes precedence over NO
+        // track > lane > (shared_lane or share_busway)
+        // Otherwise second takes precedence over first
+        if (second == Cycleway.MISSING)
+            return first;
+        else if (second == Cycleway.NO && first != Cycleway.MISSING)
+            return first;
+        else if ((first == Cycleway.TRACK || first == Cycleway.LANE) && (second == Cycleway.SHARED_LANE || second == Cycleway.SHARE_BUSWAY))
+            return first;
+        else if (first == Cycleway.TRACK && second == Cycleway.LANE)
+            return first;
+        else
+            return second;
+    }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
@@ -65,8 +65,10 @@ public class OSMCyclewayParser implements TagParser {
 
         // If we find opposite_* tags, normalize them, and treat that as the final word
         // (discounting any contradictory left/right tags which would be a tagging error).
+        // Note: in this case it's ambiguous what forward infrastructure exists, so we
+        // set to missing. This is why this kind of tagging is deprecated in OSM.
         if (oppositeLanes.containsKey(cycleway)) {
-            cyclewayForward = Cycleway.SHARED_LANE;
+            cyclewayForward = Cycleway.MISSING;
             cyclewayBackward = oppositeLanes.get(cycleway);
         } else {
             // Driving side is needed to compute default directionality of cycleway:left/right.

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
@@ -73,9 +73,16 @@ public class OSMCyclewayParser implements TagParser {
             // See defaults described in wiki:
             // https://wiki.openstreetmap.org/wiki/Key:cycleway:right:oneway
             DrivingSide drivingSide = DrivingSide.find(readerWay.getTag("driving_side"));
-            CountryRule countryRule = readerWay.getTag("country_rule", null);
-            if (countryRule != null) {
-                drivingSide = countryRule.getDrivingSide(readerWay, drivingSide);
+            if (drivingSide == DrivingSide.MISSING) {
+              // Note: This code will run in almost all cases. It's very
+              // uncommon for a way to have an exception to the driving side.
+              //
+              // Note also: country rules have to be turned on in the
+              // GraphHopper config file for this to work!
+              CountryRule countryRule = readerWay.getTag("country_rule", null);
+              if (countryRule != null) {
+                  drivingSide = countryRule.getDrivingSide(readerWay, drivingSide);
+              }
             }
             boolean isOnewayForCars = readerWay.hasTag("oneway", oneways);
 


### PR DESCRIPTION
1. On `master`, the `OSMCyclewayParser` parses `cycleway` properties for exposing to the frontend, which ultimately renders them on the map (green "lane", dashed green "shared lane", dark green "track", etc.). In doing so, it makes assumptions that are often not valid, such as that cycleways on the drive side always go forward and opposite the drive side always go backward (contradicted by two-way cycle tracks), and that one-way streets (for cars) can only have one cycleway value (contradicted by contraflow lanes). The first commit in this PR fixes these situations.
2. On `master`, `BikeCommonFlagEncoder` assumes that if a street is one-way for cars, it's also one-way for bikes, despite the fact that `oneway=yes` + `oneway:bicycle=no` is a common OSM tagging practice for a street which allows contraflow bicycle traffic (seen on Lyell St north of Alemany in SF). `BikeCommonFlagEncoder` also assumes that if a street contains a bike lane that is explicitly marked as a one-way bike lane (which is the default!), the whole street is one-way. The second commit in this PR fixes these situations, so the router can correctly use contraflow bike lanes (such as the aforesaid Lyell St).
3. On `master`, when assigning penalties based on street conditions, instead of reusing the forward and backward cycleway values computed by `OSMCyclewayParser`, `BikeCommonFlagEncoder` does its own parsing of `cycleway` tags (which also contains errors relating to one-ways, etc.). The third commit in this PR makes the flag encoder use the already parsed forward and backward cycleway values, so penalty assignment also benefits from the corrected logic in the first commit.

I've verified this correctly handles (not an exhaustive list):
1. Battery Street from Market to Vallejo, two-way cycle track, both forward and contraflow directions (previously broken)
2. Scott Street just south of Fell Street, one-way north but two-way for bikes, both directions (previously broken)
3. Lyell Street, both directions (previously broken)
4. Fell Street, one-way cycle track on one-way street (still works)
5. Indiana Street forward and contraflow bike lanes, 26th St to Cesar Chavez (previously broken)

Fixes #70 

Fixes #119