### PR TITLE
No bikes on California St cable car in SF

### DIFF
--- a/reader-gtfs/src/main/java/com/conveyal/gtfs/model/Trip.java
+++ b/reader-gtfs/src/main/java/com/conveyal/gtfs/model/Trip.java
@@ -75,14 +75,19 @@ public class Trip extends Entity {
             t.feed = feed;
             t.feed_id = feed.feedId;
 
-            // Bikes are not allowed on MUNI Metro, LRVs, cable cars, and historic vehicles
+            // Hardcoded workarounds for incomplete/wrong SF Bay Area data we've seen.
+            // We also want to look up the associated route to check referential integrity
+            // (but not store a reference; see below).
             // TODO: no longer hardcode these
-            if (Arrays.asList("SF:J", "SF:K", "SF:T", "SF:L", "SF:M", "SF:N", "SF:F", "SF:E", "SF:PH", "SF:C", "SF:PM", "SF:S")
-                    .contains(t.route_id)) {
+            Route route = getRefField("route_id", true, feed.routes);
+
+            // Bikes are only allowed on SFMTA/Muni buses including trolleybuses,
+            // not on any other trip types (LRV, cable car, etc.) operated by the agency.
+            if (route.agency_id.equals("SF") && route.route_type != 3 && route.route_type != 11) {
                 t.bikes_allowed = 2;
             }
-            // Bikes are allowed on County Connection busses but the data is wrong
-            if (t.route_id.startsWith("CC:")) {
+            // Bikes are allowed on County Connection busses but the data is wrong (May 2023)
+            if (route.agency_id.equals("CC")) {
                 t.bikes_allowed = 1;
             }
 
@@ -94,7 +99,7 @@ public class Trip extends Entity {
              */
             // TODO confirm existence of shape ID
             getRefField("service_id", true, feed.services);
-            getRefField("route_id", true, feed.routes);
+            // Route existence confirmed above
         }
 
     }


### PR DESCRIPTION
This also changes how our hardcoded bikes_allowed overrides work. Instead of hardcoding the route ID, everything for agency "SF" that isn't a bus (route_type 3) or trolley bus (in theory 11, although SFMTA currently uses 3 for all buses, but if they switched to using 11 for trolley buses this code would still work), is marked as not allowing bikes.

Verified [this route that's currently using the cable car in production](https://bikehopper.org/route/Hyatt%20Regency%20San%20Francisco%2C%205%20Embarcadero%20Center%2C%20San%20Francisco%2C%2094111@-122.39590032225456,37.79424715/to/The%20Fairmont%20San%20Francisco%20Hotel%2C%20950%20Mason%20Street%2C%20San%20Francisco%2C%2094108@-122.41003009790424,37.7923686/d/1683486960000) doesn't, in this branch, and it still avoids SFMTA light rail, but still takes SFMTA and County Connection buses.

Fixes #121. The specific change was SFMTA's GTFS started using a route ID of SF:CA instead of SF:C.