### PR TITLE
GH #86: Add LANE to withTrafficCyclewayTags

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -72,7 +72,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             boolean speedTwoDirections, boolean useFerries) {
         super(name, speedBits, speedFactor, speedTwoDirections, maxTurnCosts);
 
-        penaltyEnc = new DecimalEncodedValueImpl(getKey(name, "penalty"), 4, PenaltyCode.getFactor(1),
+        penaltyEnc = new DecimalEncodedValueImpl(getKey(name, "penalty"), 5, PenaltyCode.getFactor(0.5),
                 penaltyTwoDirections);
 
         restrictedValues.add("agricultural");

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -196,6 +196,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         cyclewayMap.put(SHARE_BUSWAY, SLIGHT_PREFER.getValue());
         cyclewayMap.put(LANE, PREFER.getValue());
         cyclewayMap.put(TRACK, VERY_NICE.getValue());
+        withTrafficCyclewayTags.add(LANE);
         withTrafficCyclewayTags.add(SHARED_LANE);
         withTrafficCyclewayTags.add(SHOULDER);
 

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -19,16 +19,14 @@ package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
-import com.graphhopper.routing.util.countryrules.CountryRule;
 import com.graphhopper.routing.weighting.PenaltyWeighting;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.Helper;
 
 import java.util.*;
-import java.util.stream.Stream;
 
-import static com.graphhopper.routing.ev.RouteNetwork.*;
 import static com.graphhopper.routing.ev.Cycleway.*;
+import static com.graphhopper.routing.ev.RouteNetwork.*;
 import static com.graphhopper.routing.util.EncodingManager.getKey;
 import static com.graphhopper.routing.util.PenaltyCode.*;
 
@@ -230,7 +228,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.MISSING, 1.0d);
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.OTHER, 0.7d);
 
-        setAvoidSpeedLimit(71);
+        // At 45km/h, the likelihood of a fatal crash rises above 1/3rd.
+        setAvoidSpeedLimit(45);
     }
 
     @Override
@@ -634,5 +633,11 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
     void setSpecificClassBicycle(String subkey) {
         classBicycleKey = "class:bicycle:" + subkey;
+    }
+
+    public final DecimalEncodedValue getPenaltyEnc() {
+        if (penaltyEnc == null)
+            throw new NullPointerException("FlagEncoder " + getName() + " not yet initialized");
+        return penaltyEnc;
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/CayugaAlemanyTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CayugaAlemanyTest.java
@@ -1,0 +1,51 @@
+package com.graphhopper.routing.util;
+
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.DecimalEncodedValue;
+import com.graphhopper.storage.IntsRef;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class CayugaAlemanyTest {
+    @Test
+    public void test_cayuga() {
+        ReaderWay cayuga = new ReaderWay(3);
+        cayuga.setTag("highway", "residential");
+        cayuga.setTag("maxspeed", "25 mph");
+        cayuga.setTag("motor_vehicle", "destination");
+
+        BikeFlagEncoder bike = new BikeFlagEncoder("bike");
+        EncodingManager encodingManager = new EncodingManager.Builder().add(bike).build();
+        IntsRef edgeFlags = encodingManager.createEdgeFlags();
+        bike.handleWayTags(edgeFlags, cayuga);
+        DecimalEncodedValue penaltyEnc = bike.getPenaltyEnc();
+
+        // "motor_vehicle=no" (no cars allowed on the given way) should clamp
+        // the way's penalty to the best assignable value.
+        assertEquals(PenaltyCode.BEST.getValue(),
+                penaltyEnc.getDecimal(false, edgeFlags));
+    }
+
+    @Test
+    public void test_alemany() {
+        ReaderWay alemany = new ReaderWay(3);
+        alemany.setTag("cycleway:right", "lane");
+        alemany.setTag("highway", "primary");
+        alemany.setTag("maxspeed", "35 mph");
+        alemany.setTag("oneway", "yes");
+
+        BikeFlagEncoder bike = new BikeFlagEncoder("bike");
+        EncodingManager encodingManager = new EncodingManager.Builder().add(bike).build();
+        IntsRef edgeFlags = encodingManager.createEdgeFlags();
+        bike.handleWayTags(edgeFlags, alemany);
+        DecimalEncodedValue penaltyEnc = bike.getPenaltyEnc();
+
+        // "motor_vehicle=no" (no cars allowed on the given way) should clamp
+        // the way's penalty to the best assignable value.
+        assertEquals(PenaltyCode.BEST.getValue(),
+                penaltyEnc.getDecimal(false, edgeFlags));
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/CayugaAlemanyTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CayugaAlemanyTest.java
@@ -50,8 +50,9 @@ public class CayugaAlemanyTest {
         IntsRef edgeFlags = encodingManager.handleWayTags(alemany, relFlags);
         DecimalEncodedValue penaltyEnc = encoder.getPenaltyEnc();
 
-        // Penalty should be PREFER because of cycleway:right=lane.
-        assertEquals(PenaltyCode.PREFER.getValue(),
+        // The penalty should be elevated because cycleway=lane is cycling
+        // infrastructure that is exposed to car traffic.
+        assertEquals(PenaltyCode.BAD.getValue(),
                 penaltyEnc.getDecimal(false, edgeFlags));
     }
 }


### PR DESCRIPTION
Fixes #86:

<img width="1728" alt="Screenshot 2024-05-07 at 23 40 17" src="https://github.com/bikehopper/graphhopper/assets/9167258/5a436888-d31e-411b-a529-2a622a31abeb">

A painted bike lane is still cycling infrastructure that is shared with car traffic. As such, ways that have `cycleway=lane` tags but also accommodate car traffic should receive a highway-based penalty. 

Adding `LANE` to `withTrafficCyclewayTags` allows existing `BikeCommonFlagEncoder` code to levy a highway-based penalty to the way. This penalty will be `p - 1`, where `p` is the highway-based `PenaltyCode`'s level.