### PR TITLE
GH #68: Add corridor to pushingSectionHighways

### DIFF
--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -648,4 +648,17 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         assertEquals(PenaltyCode.BEST.getValue(),
                 penaltyEnc.getDecimal(false, edgeFlags));
     }
+
+    // Checks that a corridor has a positive average speed.
+    @Test
+    public void testCorridor() {
+        ReaderWay corridor = new ReaderWay(1);
+        corridor.setTag("foot", "yes");
+        corridor.setTag("highway", "corridor");
+        corridor.setTag("indoor", "yes");
+        IntsRef edgeFlags = encodingManager.createEdgeFlags();
+
+        encoder.handleWayTags(edgeFlags, corridor);
+        assertEquals(PUSHING_SECTION_SPEED, avgSpeedEnc.getDecimal(false, edgeFlags));
+    }
 }


### PR DESCRIPTION
Fixes #68.

## Issue and Root Cause

When given an OSM way with `highway=corridor`, `BikeCommonFlagEncoder` was applying `EncodingManager.Access.CAN_SKIP` in `getAccess()`. This was because `corridor` wasn't being included in the `pushingSectionHighways` list.

Since the way had `CAN_SKIP` set, `BikeCommonFlagEncoder.avgSpeedEnc` was never initialized (even though `BikeCommonFlagEncoder.getSpeed()` would return a positive value). Therefore, when the edge was collected as part of a route, it was unblocked but had a speed of zero.

What we tried initially was adding the line
```
addPushingSection("corridor");
```
to the `BikeFlagEncoder` constructor.

But `BikeFlagEncoder` is a subclass of `BikeCommonFlagEncoder`, and the latter is the class that calculates average speeds for edges. So functionally, the `addPushingSection()` calls in the `BikeFlagEncoder` do nothing as the `pushingSectionHighways` list is only used in `BikeCommonFlagEncoder`, where it is always empty.

## Fix

Moving `addPushingSection()` to the `BikeCommonFlagEncoder` will ensure that all pushing sections receive a positive speed, and won't throw the "speed ≠ 0 unblocked edge" exception when collected as part of a desired route.