### PR TITLE
Transfer leg routing fixes

### DIFF
--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
@@ -111,9 +111,9 @@ public class GraphHopperGtfs extends GraphHopper {
         final int maxTransferWalkTimeSeconds = ghConfig.getInt("gtfs.max_transfer_interpolation_walk_time_seconds", 120);
         GraphHopperStorage graphHopperStorage = getGraphHopperStorage();
         QueryGraph queryGraph = QueryGraph.create(graphHopperStorage.getBaseGraph(), Collections.emptyList());
-        String transferProfileName = ghConfig.getString("pt.transfer_profile", "foot");
-        Weighting transferWeighting = createWeighting(getProfile(transferProfileName), new PMap());
-        final GraphExplorer graphExplorer = new GraphExplorer(queryGraph, ptGraph, transferWeighting, getGtfsStorage(), RealtimeFeed.empty(), true, true, false, false, false, 0);
+        String connectingProfileName = ghConfig.getString("pt.connecting_profile", "foot");
+        Weighting transferWeighting = createWeighting(getProfile(connectingProfileName), new PMap());
+        final GraphExplorer graphExplorer = new GraphExplorer(queryGraph, ptGraph, transferWeighting, getGtfsStorage(), RealtimeFeed.empty(), true, true, false, true, false, 0);
         getGtfsStorage().getStationNodes().values().stream().distinct().map(n -> {
             int streetNode = Optional.ofNullable(gtfsStorage.getPtToStreet().get(n)).orElse(-1);
             return new Label.NodeId(streetNode, n);


### PR DESCRIPTION
- The config param is called pt.connecting_profile, not pt.transfer_profile
- isBike should be true in GraphExplorer constructor

I was hoping these fixes would resolve the bug described in issue #68, but unfortunately, they don't, but this still seems to be the correct thing to do (while having no immediate visible effect as far as I can tell).