### PR TITLE
Disable grade penalties

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/Bike2WeightFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/Bike2WeightFlagEncoder.java
@@ -135,8 +135,9 @@ public class Bike2WeightFlagEncoder extends BikeFlagEncoder {
         int grade = edge.getGrade();
         IntsRef edgeFlags = edge.getFlags();
         Double forwardPenalty = penaltyEnc.getDecimal(false, edgeFlags);
-        Double newForwardPenalty = gradePenaltyMap.get(boundaryFor(grade)).apply(forwardPenalty);
-        penaltyEnc.setDecimal(false, edgeFlags, newForwardPenalty);
+        // Grade penalties are temporarily disabled due to bad elevation data.
+        // forwardPenalty = gradePenaltyMap.get(boundaryFor(grade)).apply(forwardPenalty);
+        penaltyEnc.setDecimal(false, edgeFlags, forwardPenalty);
 
         Double backwardPenalty = penaltyEnc.getDecimal(true, edgeFlags);
         Double newBackwardPenalty = gradePenaltyMap.get(boundaryFor(-1 * grade)).apply(backwardPenalty);


### PR DESCRIPTION
Until we get better quality data, it might be a net positive to disable grade penalties.

It greatly improves routes along the Polk corridor:
![cityhall-alhambra-with-elev](https://github.com/bikehopper/graphhopper/assets/1730853/cf6636ff-6726-4d37-a1b8-e2390c8949bf)
![cityhall-alhambra-no-elev](https://github.com/bikehopper/graphhopper/assets/1730853/66fcf851-8572-4cb5-ae85-5142db5cf7b1)

![robins-to-ina-with-gp](https://github.com/bikehopper/graphhopper/assets/1730853/184e3bba-2baa-45a0-9901-8bfda04162fe)
![robins-to-ina-no-gp](https://github.com/bikehopper/graphhopper/assets/1730853/031f7c2f-1c4c-4265-bd49-8b8159d8b00b)

And only slightly worsens a route using the Page Divis hill:
![dolo-to-beit-rima-w-elev](https://github.com/bikehopper/graphhopper/assets/1730853/bb6d87e2-666a-46b9-b0e9-4a47aca0687a)
![dolo-to-beit-rima-no-elev](https://github.com/bikehopper/graphhopper/assets/1730853/ff8b4498-c490-48d1-9be3-aacc0fc17c23)
