### PR TITLE
Ingest Generalized 1/9 Arcsecond Data

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
@@ -74,20 +74,18 @@ public class USGSProvider extends AbstractTiffElevationProvider {
         String filename = "ned19_n";
 
         double latAdjusted = Math.abs(Math.ceil(lat * 4) / 4);
-        String latString = String.valueOf(latAdjusted);
-        int indLat = latString.indexOf('.');
-        if(latString.length() < indLat + 3) {
-            latString += "0";
-        }
-        filename += latString.substring(0, indLat) + "x" + latString.substring(indLat + 1) + "_";
+        int latDigits = (int) Math.floor(latAdjusted);
+        filename += latDigits + "x";
+        int latQuarter = (int)(latAdjusted * 100) % 100;
+        if(latQuarter == 0) filename += "0";
+        filename += latQuarter + "_w";
 
         double lonAdjusted = Math.abs(getMinLonForTile(lon));
-        String lonString = String.valueOf(lonAdjusted);
-        int indLon = lonString.indexOf('.');
-        if(lonString.length() < indLon + 3) {
-            lonString += "0";
-        }
-        filename += "w" + lonString.substring(0, indLon) + "x" + lonString.substring(indLon + 1);
+        int lonDigits = (int) Math.floor(lonAdjusted);
+        filename += lonDigits + "x";
+        int lonQuarter = (int)(lonAdjusted * 100) % 100;
+        if(lonQuarter == 0) filename += "0";
+        filename += lonQuarter;
 
         return filename;
     }

--- a/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
@@ -71,23 +71,15 @@ public class USGSProvider extends AbstractTiffElevationProvider {
      */
     @Override
     String getFileName(double lat, double lon) {
-        String filename = "ned19_n";
-
         double latAdjusted = Math.abs(Math.ceil(lat * 4) / 4);
         int latDigits = (int) Math.floor(latAdjusted);
-        filename += latDigits + "x";
-        int latQuarter = (int)(latAdjusted * 100) % 100;
-        if(latQuarter == 0) filename += "0";
-        filename += latQuarter + "_w";
+        int latDecimals = (int)(latAdjusted * 100) % 100;
 
         double lonAdjusted = Math.abs(getMinLonForTile(lon));
         int lonDigits = (int) Math.floor(lonAdjusted);
-        filename += lonDigits + "x";
-        int lonQuarter = (int)(lonAdjusted * 100) % 100;
-        if(lonQuarter == 0) filename += "0";
-        filename += lonQuarter;
+        int lonDecimals = (int)(lonAdjusted * 100) % 100;
 
-        return filename;
+        return String.format("ned19_n%dx%02d_w%dx%02d", latDigits, latDecimals, lonDigits, lonDecimals);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
@@ -72,14 +72,12 @@ public class USGSProvider extends AbstractTiffElevationProvider {
     @Override
     String getFileName(double lat, double lon) {
         double latAdjusted = Math.abs(Math.ceil(lat * 4) / 4);
-        int latDigits = (int) Math.floor(latAdjusted);
         int latDecimals = (int)(latAdjusted * 100) % 100;
 
         double lonAdjusted = Math.abs(getMinLonForTile(lon));
-        int lonDigits = (int) Math.floor(lonAdjusted);
         int lonDecimals = (int)(lonAdjusted * 100) % 100;
 
-        return String.format("ned19_n%dx%02d_w%dx%02d", latDigits, latDecimals, lonDigits, lonDecimals);
+        return String.format("ned19_n%dx%02d_w%dx%02d", (int) latAdjusted, latDecimals, (int) lonAdjusted, lonDecimals);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
@@ -57,9 +57,9 @@ public class USGSProvider extends AbstractTiffElevationProvider {
     /**
      * The USGS National Elevation Dataset (NED)'s 1/9th arc-second DEM offering
      * categorizes individual 0.25x0.25 degree tiles using the northwestern
-     * corner of each tile. For example, ned19_n37x75_w122x50 means that the
-     * corners of the tile are (starting from the northwestern corner and moving
-     * clockwise):
+     * corner of each tile. For example, <i>ned19_n37x75_w122x50</i> means that
+     * the corners of the tile are (starting from the northwestern corner and
+     * moving clockwise):
      * <ul>
      *   <li>37.75, -122.50</li>
      *   <li>37.75, -122.25</li>
@@ -68,7 +68,8 @@ public class USGSProvider extends AbstractTiffElevationProvider {
      * </ul>
      * @param lat latitude in degrees, ranges from [-90.0, 90.0]
      * @param lon longitude in degrees, ranges from [-180.0, 180.0]
-     * @return
+     * @return Filename in format ned19_{n,s}AAxAA_{e,w}BBBxBB;
+     * AAxAA being latitude in degrees and BBBxBB being longitude in degrees
      */
     @Override
     String getFileName(double lat, double lon) {

--- a/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
@@ -58,7 +58,7 @@ public class USGSProvider extends AbstractTiffElevationProvider {
     }
 
     /**
-     * The USGS National Elevation Dataset (NED)'s 1/9th arc-second offering
+     * The USGS National Elevation Dataset (NED)'s 1/9th arc-second DEM offering
      * categorizes individual 0.25x0.25 degree tiles using the northwestern
      * corner of each tile. For example, ned19_n37x75_w122x50 means that the
      * corners of the tile are (starting from the northwestern corner and moving
@@ -69,8 +69,8 @@ public class USGSProvider extends AbstractTiffElevationProvider {
      *   <li>37.50, -122.25</li>
      *   <li>37.50, -122.50</li>
      * </ul>
-     * @param lat
-     * @param lon
+     * @param lat latitude in degrees, ranges from [-90.0, 90.0]
+     * @param lon longitude in degrees, ranges from [-180.0, 180.0]
      * @return
      */
     @Override

--- a/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
@@ -12,7 +12,6 @@ import org.apache.xmlgraphics.image.codec.tiff.TIFFImageDecoder;
 import org.apache.xmlgraphics.image.codec.util.SeekableStream;
 
 public class USGSProvider extends AbstractTiffElevationProvider {
-    String filename = "ned19_n38w122x50";
 
     public USGSProvider(String cacheDir) {
         this("", cacheDir, "", 8112, 8112, 0.25, 0.25);
@@ -50,8 +49,7 @@ public class USGSProvider extends AbstractTiffElevationProvider {
 
     @Override
     String getFileNameOfLocalFile(double lat, double lon) {
-        // TODO(steveliu): Implement.
-        return filename + ".tif";
+        return getFileName(lat, lon) + ".tif";
     }
 
     /**
@@ -73,7 +71,7 @@ public class USGSProvider extends AbstractTiffElevationProvider {
      */
     @Override
     String getFileName(double lat, double lon) {
-        filename = "ned19_";
+        String filename = "ned19_n";
 
         double latAdjusted = Math.abs(Math.ceil(lat * 4) / 4);
         String latString = String.valueOf(latAdjusted);
@@ -81,9 +79,9 @@ public class USGSProvider extends AbstractTiffElevationProvider {
         if(latString.length() < indLat + 3) {
             latString += "0";
         }
-        filename += "n" + latString.substring(0, indLat) + "x" + latString.substring(indLat + 1) + "_";
+        filename += latString.substring(0, indLat) + "x" + latString.substring(indLat + 1) + "_";
 
-        double lonAdjusted = Math.abs(Math.floor(lon * 4) / 4);
+        double lonAdjusted = Math.abs(getMinLonForTile(lon));
         String lonString = String.valueOf(lonAdjusted);
         int indLon = lonString.indexOf('.');
         if(lonString.length() < indLon + 3) {

--- a/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
@@ -42,13 +42,13 @@ public class USGSProvider extends AbstractTiffElevationProvider {
     @Override
     double getMinLatForTile(double lat) {
         // TODO(steveliu): Implement.
-        return 37.75;
+        return (double) Math.floor(lat * 4) / 4;
     }
 
     @Override
     double getMinLonForTile(double lon) {
         // TODO(steveliu): Implement.
-        return -122.5;
+        return (double) Math.floor(lon * 4) / 4;
     }
 
     @Override
@@ -76,6 +76,24 @@ public class USGSProvider extends AbstractTiffElevationProvider {
     @Override
     String getFileName(double lat, double lon) {
         // TODO(steveliu): Implement.
+        filename = "ned19_";
+
+        double latAdjusted = Math.abs(Math.ceil(lat * 4) / 4);
+        String latString = String.valueOf(latAdjusted);
+        int indLat = latString.indexOf('.');
+        if(latString.length() < indLat + 3) {
+            latString += "0";
+        }
+        filename += "n" + latString.substring(0, indLat) + "x" + latString.substring(indLat + 1) + "_";
+
+        double lonAdjusted = Math.abs(Math.floor(lon * 4) / 4);
+        String lonString = String.valueOf(lonAdjusted);
+        int indLon = lonString.indexOf('.');
+        if(lonString.length() < indLon + 3) {
+            lonString += "0";
+        }
+        filename += "w" + lonString.substring(0, indLon) + "x" + lonString.substring(indLon + 1);
+
         return filename;
     }
 

--- a/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
@@ -12,7 +12,6 @@ import org.apache.xmlgraphics.image.codec.tiff.TIFFImageDecoder;
 import org.apache.xmlgraphics.image.codec.util.SeekableStream;
 
 public class USGSProvider extends AbstractTiffElevationProvider {
-    // TODO(steveliu): Remove and implement getFileName() instead.
     String filename = "ned19_n38w122x50";
 
     public USGSProvider(String cacheDir) {
@@ -41,12 +40,12 @@ public class USGSProvider extends AbstractTiffElevationProvider {
 
     @Override
     double getMinLatForTile(double lat) {
-        return (double) Math.floor(lat * 4) / 4;
+        return Math.floor(lat * 4) / 4;
     }
 
     @Override
     double getMinLonForTile(double lon) {
-        return (double) Math.floor(lon * 4) / 4;
+        return Math.floor(lon * 4) / 4;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
@@ -12,8 +12,8 @@ import org.apache.xmlgraphics.image.codec.tiff.TIFFImageDecoder;
 import org.apache.xmlgraphics.image.codec.util.SeekableStream;
 
 public class USGSProvider extends AbstractTiffElevationProvider {
-
-    String filename = "ned19_n37x75_w122x00_gscale";
+    // TODO(steveliu): Remove and implement getFileName() instead.
+    String filename = "ned19_n38w122x50";
 
     public USGSProvider(String cacheDir) {
         this("", cacheDir, "", 8112, 8112, 0.25, 0.25);
@@ -24,17 +24,14 @@ public class USGSProvider extends AbstractTiffElevationProvider {
             double lonDegree) {
         super(baseUrl, cacheDir, downloaderName, width, height, latDegree,
                 lonDegree);
-        setInterpolate(true);
     }
 
     public static void main(String[] args) {
         USGSProvider elevationProvider = new USGSProvider("/tmp/");
 
         // Market Street ~-5ft to 260ft in prod.
-//        System.out.println("Elevation: " + elevationProvider.getEle(37.7903317182555, -122.39999824547087) + "m");
-//        System.out.println("Elevation: " + elevationProvider.getEle(37.79112431722635, -122.39901032204128) + "m");
-        System.out.println("Elevation: " + elevationProvider.getEle(37.7499, -122.0001) + "m");
-        System.out.println("Elevation: " + elevationProvider.getEle(37.5001, -122.0001) + "m");
+        System.out.println("Elevation: " + elevationProvider.getEle(37.7903317182555, -122.39999824547087) + "m");
+        System.out.println("Elevation: " + elevationProvider.getEle(37.79112431722635, -122.39901032204128) + "m");
     }
 
     @Override
@@ -44,21 +41,41 @@ public class USGSProvider extends AbstractTiffElevationProvider {
 
     @Override
     double getMinLatForTile(double lat) {
-        return 37.5;
+        // TODO(steveliu): Implement.
+        return 37.75;
     }
 
     @Override
     double getMinLonForTile(double lon) {
-        return -122.25;
+        // TODO(steveliu): Implement.
+        return -122.5;
     }
 
     @Override
     String getFileNameOfLocalFile(double lat, double lon) {
+        // TODO(steveliu): Implement.
         return filename + ".tif";
     }
 
+    /**
+     * The USGS National Elevation Dataset (NED)'s 1/9th arc-second offering
+     * categorizes individual 0.25x0.25 degree tiles using the northwestern
+     * corner of each tile. For example, ned19_n37x75_w122x50 means that the
+     * corners of the tile are (starting from the northwestern corner and moving
+     * clockwise):
+     * <ul>
+     *   <li>37.75, -122.50</li>
+     *   <li>37.75, -122.25</li>
+     *   <li>37.50, -122.25</li>
+     *   <li>37.50, -122.50</li>
+     * </ul>
+     * @param lat
+     * @param lon
+     * @return
+     */
     @Override
     String getFileName(double lat, double lon) {
+        // TODO(steveliu): Implement.
         return filename;
     }
 

--- a/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/USGSProvider.java
@@ -41,13 +41,11 @@ public class USGSProvider extends AbstractTiffElevationProvider {
 
     @Override
     double getMinLatForTile(double lat) {
-        // TODO(steveliu): Implement.
         return (double) Math.floor(lat * 4) / 4;
     }
 
     @Override
     double getMinLonForTile(double lon) {
-        // TODO(steveliu): Implement.
         return (double) Math.floor(lon * 4) / 4;
     }
 
@@ -75,7 +73,6 @@ public class USGSProvider extends AbstractTiffElevationProvider {
      */
     @Override
     String getFileName(double lat, double lon) {
-        // TODO(steveliu): Implement.
         filename = "ned19_";
 
         double latAdjusted = Math.abs(Math.ceil(lat * 4) / 4);

--- a/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
@@ -13,10 +13,18 @@ class USGSProviderTest {
         assertEquals(37.75, provider.getMinLatForTile(37.76));
         assertEquals(37.5, provider.getMinLatForTile(37.75));
         assertEquals(37.5, provider.getMinLatForTile(37.74));
+
+        assertEquals(-38, provider.getMinLatForTile(-37.76));
+        assertEquals(-37.75, provider.getMinLatForTile(-37.75));
+        assertEquals(-37.75, provider.getMinLatForTile(-37.74));
     }
 
     @Test
     public void testMinLon() {
+        assertEquals(122.25, provider.getMinLonForTile(122.26));
+        assertEquals(122.25, provider.getMinLonForTile(122.25));
+        assertEquals(122, provider.getMinLonForTile(122.24));
+
         assertEquals(-122.5, provider.getMinLonForTile(-122.26));
         assertEquals(-122.25, provider.getMinLonForTile(-122.25));
         assertEquals(-122.25, provider.getMinLonForTile(-122.24));

--- a/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
@@ -1,6 +1,6 @@
 package com.graphhopper.reader.dem;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,16 +9,23 @@ class USGSProviderTest {
     USGSProvider provider = new USGSProvider("");
 
     @Test
-    public void testFilename() {
-        assertEquals("ned19_n38x00w122x50",
-                provider.getFileName(38, -122.5));
-        assertEquals("ned19_n37x75w122x00",
-                provider.getFileName(37, -122));
+    public void testMinLat() {
+        assertEquals(37.75, provider.getMinLatForTile(37.76));
+        assertEquals(37.5, provider.getMinLatForTile(37.75));
+        assertEquals(37.5, provider.getMinLatForTile(37.74));
     }
 
     @Test
-    public void testMinLat() {
-        assertEquals(37.75, provider.getMinLatForTile(37.99));
-        assertEquals(38, provider.getMinLatForTile(38));
+    public void testMinLon() {
+        assertEquals(-122.5, provider.getMinLonForTile(-122.26));
+        assertEquals(-122, provider.getMinLonForTile(-122));
+    }
+
+    @Test
+    public void testFilename() {
+        assertEquals("ned19_n38x00w122x50",
+                provider.getFileName(38, -122.5));
+        assertEquals("ned19_n38x00w122x50",
+                provider.getFileName(37.76, -122.26));
     }
 }

--- a/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
@@ -1,0 +1,21 @@
+package com.graphhopper.reader.dem;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class USGSProviderTest {
+    @Test
+    public void testFilename() {
+        USGSProvider provider = new USGSProvider("");
+        assertEquals("ned19_n38x00w122x50",
+                provider.getFileName(38.00, -122.50));
+    }
+
+    @Test
+    public void testMinLat() {
+        USGSProvider provider = new USGSProvider("");
+        assertEquals(37.75, provider.getMinLatForTile(37.99));
+        assertEquals(38, provider.getMinLatForTile(38));
+    }
+}

--- a/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
@@ -5,16 +5,19 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 class USGSProviderTest {
+
+    USGSProvider provider = new USGSProvider("");
+
     @Test
     public void testFilename() {
-        USGSProvider provider = new USGSProvider("");
         assertEquals("ned19_n38x00w122x50",
-                provider.getFileName(38.00, -122.50));
+                provider.getFileName(38, -122.5));
+        assertEquals("ned19_n37x75w122x00",
+                provider.getFileName(37, -122));
     }
 
     @Test
     public void testMinLat() {
-        USGSProvider provider = new USGSProvider("");
         assertEquals(37.75, provider.getMinLatForTile(37.99));
         assertEquals(38, provider.getMinLatForTile(38));
     }

--- a/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
@@ -18,7 +18,8 @@ class USGSProviderTest {
     @Test
     public void testMinLon() {
         assertEquals(-122.5, provider.getMinLonForTile(-122.26));
-        assertEquals(-122, provider.getMinLonForTile(-122));
+        assertEquals(-122.25, provider.getMinLonForTile(-122.25));
+        assertEquals(-122.25, provider.getMinLonForTile(-122.24));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
@@ -11,7 +11,7 @@ class USGSProviderTest {
     @Test
     public void testMinLat() {
         assertEquals(37.75, provider.getMinLatForTile(37.76));
-        assertEquals(37.5, provider.getMinLatForTile(37.75));
+        assertEquals(37.75, provider.getMinLatForTile(37.75));
         assertEquals(37.5, provider.getMinLatForTile(37.74));
 
         assertEquals(-38, provider.getMinLatForTile(-37.76));

--- a/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/USGSProviderTest.java
@@ -32,9 +32,9 @@ class USGSProviderTest {
 
     @Test
     public void testFilename() {
-        assertEquals("ned19_n38x00w122x50",
+        assertEquals("ned19_n38x00_w122x50",
                 provider.getFileName(38, -122.5));
-        assertEquals("ned19_n38x00w122x50",
+        assertEquals("ned19_n38x00_w122x50",
                 provider.getFileName(37.76, -122.26));
     }
 }


### PR DESCRIPTION
Expands the `USGSProvider` to accept a wider range of 1/9 Arcsecond TIFFs.