### PR TITLE
Visualize OSM Ways data on a Map

### DIFF
--- a/bay-area/config-local.yml
+++ b/bay-area/config-local.yml
@@ -181,6 +181,8 @@ graphhopper:
   # Use this flag to enable these rules (you need to repeat the import for changes to take effect)
   country_rules.enabled: true
 
+  logging.ways_dump_file: logs/ways_dump.ldgeojson
+
 # Dropwizard server configuration
 server:
   application_connectors:

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -480,6 +480,7 @@ public class GraphHopper {
         osmReaderConfig.setSmoothElevation(ghConfig.getBool("graph.elevation.smoothing", osmReaderConfig.isSmoothElevation()));
         osmReaderConfig.setLongEdgeSamplingDistance(ghConfig.getDouble("graph.elevation.long_edge_sampling_distance", osmReaderConfig.getLongEdgeSamplingDistance()));
         osmReaderConfig.setElevationMaxWayPointDistance(ghConfig.getDouble("graph.elevation.way_point_max_distance", osmReaderConfig.getElevationMaxWayPointDistance()));
+        osmReaderConfig.setWaysDumpPath(ghConfig.getString("logging.ways_dump_file", ""));
         routerConfig.setElevationWayPointMaxDistance(ghConfig.getDouble("graph.elevation.way_point_max_distance", routerConfig.getElevationWayPointMaxDistance()));
         ElevationProvider elevationProvider = createElevationProvider(ghConfig);
         setElevationProvider(elevationProvider);

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -110,9 +110,11 @@ public class OSMReader {
         turnCostStorage = baseGraph.getTurnCostStorage();
 
         try {
-            Path filePath = Paths.get("logs/ways_dump.ldgeojson");
-            Files.deleteIfExists(filePath);
-            ldGeojsonWriter = Files.newBufferedWriter(filePath, StandardOpenOption.CREATE);
+            if (config.shouldDumpWays()){
+                Path filePath = Paths.get(config.getWaysDumpPath());
+                Files.deleteIfExists(filePath);
+                ldGeojsonWriter = Files.newBufferedWriter(filePath, StandardOpenOption.CREATE);
+            }
         } catch (Exception e) {
             LOGGER.error("Error creating logs/ways_dump.ldgeojson file writer");
             e.printStackTrace();

--- a/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
+++ b/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
@@ -26,9 +26,22 @@ public class OSMReaderConfig {
     private boolean smoothElevation = false;
     private double longEdgeSamplingDistance = Double.MAX_VALUE;
     private int workerThreads = 2;
+    private String waysDumpPath = "";
 
     public String getPreferredLanguage() {
         return preferredLanguage;
+    }
+
+    public void setWaysDumpPath(String dumpPath) {
+        this.waysDumpPath = dumpPath;
+    }
+
+    public String getWaysDumpPath() {
+        return this.waysDumpPath;
+    }
+
+    public boolean shouldDumpWays() {
+        return this.waysDumpPath.length() > 0;
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/util/TagParserManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TagParserManager.java
@@ -569,14 +569,62 @@ public class TagParserManager implements EncodedValueLookup {
         return getEncodedValue(key, BooleanEncodedValue.class);
     }
 
+    public HashMap<String, Boolean> getBooleanEncodedValues(IntsRef flags) {
+        HashMap<String, Boolean> ret = new HashMap<String, Boolean>();
+        for (Map.Entry<String, EncodedValue> entry : encodedValueMap.entrySet()) {
+            EncodedValue value = entry.getValue();
+            if (value instanceof BooleanEncodedValue) {
+                BooleanEncodedValue casted = (BooleanEncodedValue) value;
+                ret.put(entry.getKey(), casted.getBool(false, flags));
+                if (casted.isStoreTwoDirections()) {
+                    ret.put(entry.getKey() + "_reversed", casted.getBool(true, flags));
+                }
+            }
+        }
+
+        return ret;
+    }
+
     @Override
     public IntEncodedValue getIntEncodedValue(String key) {
         return getEncodedValue(key, IntEncodedValue.class);
     }
 
+    public HashMap<String, Integer> getIntEncodedValues(IntsRef flags) {
+        HashMap<String, Integer> ret = new HashMap<String, Integer>();
+        for (Map.Entry<String, EncodedValue> entry : encodedValueMap.entrySet()) {
+            EncodedValue value = entry.getValue();
+            if (value instanceof IntEncodedValue) {
+                IntEncodedValue casted = (IntEncodedValue) value;
+                ret.put(entry.getKey(), casted.getInt(false, flags));
+                if (casted.isStoreTwoDirections()) {
+                    ret.put(entry.getKey() + "_reversed", casted.getInt(true, flags));
+                }
+            }
+        }
+
+        return ret;
+    }
+
     @Override
     public DecimalEncodedValue getDecimalEncodedValue(String key) {
         return getEncodedValue(key, DecimalEncodedValue.class);
+    }
+
+    public HashMap<String, Double> getDecimalEncodedValues(IntsRef flags) {
+        HashMap<String, Double> ret = new HashMap<String, Double>();
+        for (Map.Entry<String, EncodedValue> entry : encodedValueMap.entrySet()) {
+            EncodedValue value = entry.getValue();
+            if (value instanceof DecimalEncodedValue) {
+                DecimalEncodedValue casted = (DecimalEncodedValue) value;
+                ret.put(entry.getKey(), casted.getDecimal(false, flags));
+                if (casted.isStoreTwoDirections()) {
+                    ret.put(entry.getKey() + "_reversed", casted.getDecimal(true, flags));
+                }
+            }
+        }
+
+        return ret;
     }
 
     @SuppressWarnings("unchecked")

--- a/index.html
+++ b/index.html
@@ -49,8 +49,24 @@
                 'source': 'routes-tiles',
                 'paint': {
                 'line-width': 3,
-                'line-color': 'red'
-                }
+                'line-color': [
+                    'interpolate',
+                    ['linear'],
+                    ['line-progress'],
+                    0,
+                    'blue',
+                    5,
+                    'royalblue',
+                    10,
+                    'cyan',
+                    15,
+                    'lime',
+                    20,
+                    'yellow',
+                    25,
+                    'red'
+                ]
+            }
             });
         });
     });

--- a/index.html
+++ b/index.html
@@ -52,18 +52,18 @@
                 'line-color': [
                     'interpolate',
                     ['linear'],
-                    ['line-progress'],
+                    ['to-number', ['get', 'bike2$penalty']],
                     0,
                     'blue',
-                    5,
+                    1,
                     'royalblue',
-                    10,
+                    2,
                     'cyan',
-                    15,
+                    3,
                     'lime',
-                    20,
+                    4,
                     'yellow',
-                    25,
+                    5,
                     'red'
                 ]
             }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>PMTiles source and protocol</title>
+    <meta property="og:description" content="Uses the PMTiles plugin and protocol to present a map." />
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel='stylesheet' href='https://unpkg.com/maplibre-gl@4.4.1/dist/maplibre-gl.css' />
+    <script src='https://unpkg.com/maplibre-gl@4.4.1/dist/maplibre-gl.js'></script>
+    <script src="https://unpkg.com/pmtiles@3.0.6/dist/pmtiles.js"></script>
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+<body>
+<div id="map"></div>
+<script>
+
+    // add the PMTiles plugin to the maplibregl global.
+    const protocol = new pmtiles.Protocol();
+    maplibregl.addProtocol('pmtiles', protocol.tile);
+
+    const PMTILES_URL = 'http://localhost:8080/logs/out.pmtiles';
+
+    const p = new pmtiles.PMTiles(PMTILES_URL);
+
+    // this is so we share one instance across the JS code and the map renderer
+    protocol.add(p);
+
+    // we first fetch the header so we can get the center lon, lat of the map.
+    p.getHeader().then(h => {
+        var map = new maplibregl.Map({
+            container: 'map', // container id
+            style: 'https://api.maptiler.com/maps/basic-v2/style.json?key=WT4VsZ6xeluYL5zzsbwL', // style URL
+            center: [0, 0], // starting position [lng, lat]
+            zoom: 1 // starting zoom
+        });
+        map.on('load', () => {
+            map.addSource('routes-tiles', {
+                type: 'vector',
+                url: `pmtiles://${PMTILES_URL}`,
+            });
+
+            map.addLayer({
+                'id': 'route-lines',
+                'source-layer': 'ways_dump',
+                'type': 'line',
+                'source': 'routes-tiles',
+                'paint': {
+                'line-width': 3,
+                'line-color': 'red'
+                }
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     p.getHeader().then(h => {
         var map = new maplibregl.Map({
             container: 'map', // container id
-            style: 'https://api.maptiler.com/maps/basic-v2/style.json?key=WT4VsZ6xeluYL5zzsbwL', // style URL
+            style: 'https://api.maptiler.com/maps/basic-v2-dark/style.json?key=WT4VsZ6xeluYL5zzsbwL', // style URL
             center: [0, 0], // starting position [lng, lat]
             zoom: 1 // starting zoom
         });
@@ -48,23 +48,19 @@
                 'type': 'line',
                 'source': 'routes-tiles',
                 'paint': {
-                'line-width': 3,
+                'line-width': 1,
                 'line-color': [
                     'interpolate',
                     ['linear'],
                     ['to-number', ['get', 'bike2$penalty']],
-                    0,
-                    'blue',
-                    1,
-                    'royalblue',
-                    2,
-                    'cyan',
-                    3,
-                    'lime',
-                    4,
-                    'yellow',
-                    5,
-                    'red'
+                    0, 'rgb(252, 255, 164)',
+                    0.5, 'rgb(250, 193, 39)',
+                    1, 'rgb(245, 125, 21)',
+                    1.5, 'rgb(212, 72, 66)',
+                    2, 'rgb(159, 42, 99)',
+                    2.5, 'rgb(101, 21, 110)',
+                    3, 'rgb(40, 11, 84)',
+                    3.5, 'rgb(0, 0, 4)',
                 ]
             }
             });

--- a/reader-gtfs/README.md
+++ b/reader-gtfs/README.md
@@ -35,7 +35,7 @@ Requirements:
 
 Run to generate a pmtiles tileset:
 ```
-/graphhopper/logs> $ tippecanoe -zg -l ways_dump -P -o out.pmtiles --drop-densest-as-needed ways_dump.ldgeojson
+/graphhopper/logs> $ tippecanoe -z14 -Z8 -l ways_dump -P -o out.pmtiles --drop-fraction-as-needed ways_dump.ldgeojson
 ```
 
 Run to serve viz page:

--- a/reader-gtfs/README.md
+++ b/reader-gtfs/README.md
@@ -35,7 +35,7 @@ Requirements:
 
 Run to generate a pmtiles tileset:
 ```
-/graphhopper/logs> $ tippecanoe -zg -l ways_dump -P -o out.pmtiles ways_dump.ldgeojson
+/graphhopper/logs> $ tippecanoe -zg -l ways_dump -P -o out.pmtiles --drop-densest-as-needed ways_dump.ldgeojson
 ```
 
 Run to serve viz page:

--- a/reader-gtfs/README.md
+++ b/reader-gtfs/README.md
@@ -32,15 +32,17 @@ Alternatively, for a more specialized but more minimal demo of transit routing, 
 Requirements: 
 - `http-server`: https://www.npmjs.com/package/http-server (installed globally)
 - `tippecanoe`: https://github.com/felt/tippecanoe 
+- A MapLibre API key (for visualizing maps only)
 
 Run to generate a pmtiles tileset:
 ```
 /graphhopper/logs> $ tippecanoe -z14 -Z8 -l ways_dump -P -o out.pmtiles --drop-fraction-as-needed ways_dump.ldgeojson
 ```
+- Add a your MapLibre API key to `readger-gtfs/index.html`
 
 Run to serve viz page:
 ```
-/graphhopper> $ http-server --cors
+/graphhopper/reader-gtfs> $ http-server --cors
 ```
 
 # Graph schema

--- a/reader-gtfs/README.md
+++ b/reader-gtfs/README.md
@@ -27,6 +27,22 @@ When this is finished you can point your browser to http://localhost:8989
 Alternatively, for a more specialized but more minimal demo of transit routing, to http://localhost:8989/maps/pt/
 (make sure to include the trailing slash).
 
+# Visualizing Processed OSM Ways
+
+Requirements: 
+- `http-server`: https://www.npmjs.com/package/http-server (installed globally)
+- `tippecanoe`: https://github.com/felt/tippecanoe 
+
+Run to generate a pmtiles tileset:
+```
+/graphhopper/logs> $ tippecanoe -zg -l ways_dump -P -o out.pmtiles ways_dump.ldgeojson
+```
+
+Run to serve viz page:
+```
+/graphhopper> $ http-server --cors
+```
+
 # Graph schema
 
 ![Graph schema](pt-model.png)

--- a/reader-gtfs/index.html
+++ b/reader-gtfs/index.html
@@ -32,7 +32,7 @@
     p.getHeader().then(h => {
         var map = new maplibregl.Map({
             container: 'map', // container id
-            style: 'https://api.maptiler.com/maps/basic-v2-dark/style.json?key=WT4VsZ6xeluYL5zzsbwL', // style URL
+            style: 'https://api.maptiler.com/maps/basic-v2-dark/style.json?key=<MAP_LIBRE_KEY_HERE>', // style URL
             center: [0, 0], // starting position [lng, lat]
             zoom: 1 // starting zoom
         });
@@ -53,14 +53,9 @@
                     'interpolate',
                     ['linear'],
                     ['to-number', ['get', 'bike2$penalty']],
-                    0, 'rgb(252, 255, 164)',
-                    0.5, 'rgb(250, 193, 39)',
-                    1, 'rgb(245, 125, 21)',
-                    1.5, 'rgb(212, 72, 66)',
-                    2, 'rgb(159, 42, 99)',
-                    2.5, 'rgb(101, 21, 110)',
-                    3, 'rgb(40, 11, 84)',
-                    3.5, 'rgb(0, 0, 4)',
+                    1, 'rgb(194,217,85)',
+                    7, 'rgb(219,157,0)',
+                    15, 'rgb(216,98,0)',
                 ]
             }
             });

--- a/web-api/src/main/java/com/graphhopper/util/PointList.java
+++ b/web-api/src/main/java/com/graphhopper/util/PointList.java
@@ -17,6 +17,8 @@
  */
 package com.graphhopper.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.graphhopper.util.shapes.GHPoint;
 import com.graphhopper.util.shapes.GHPoint3D;
 import org.locationtech.jts.geom.Coordinate;
@@ -25,6 +27,7 @@ import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -346,6 +349,36 @@ public class PointList implements Iterable<GHPoint3D>, PointAccess {
             }
             sb.append(')');
         }
+        return sb.toString();
+    }
+
+    public String toGeojsonString(HashMap<String, String> properties) {
+        StringBuilder sb = new StringBuilder();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String propJsonString = "{}";
+        try {
+            propJsonString = objectMapper.writeValueAsString(properties);
+        } catch (JsonProcessingException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        sb.append("{\"type\": \"Feature\", \"properties\": "+propJsonString+",\"geometry\": {\"type\": \"LineString\", \"coordinates\": [");
+        for (int i = 0; i < size(); i++) {
+            if (i > 0)
+                sb.append(", ");
+
+            sb.append('[');
+            sb.append(this.getLat(i));
+            sb.append(',');
+            sb.append(this.getLon(i));
+            if (this.is3D()) {
+                sb.append(',');
+                sb.append(this.getEle(i));
+            }
+            sb.append(']');
+        }
+
+        sb.append("]}}");
         return sb.toString();
     }
 

--- a/web-api/src/main/java/com/graphhopper/util/PointList.java
+++ b/web-api/src/main/java/com/graphhopper/util/PointList.java
@@ -368,9 +368,9 @@ public class PointList implements Iterable<GHPoint3D>, PointAccess {
                 sb.append(", ");
 
             sb.append('[');
-            sb.append(this.getLat(i));
-            sb.append(',');
             sb.append(this.getLon(i));
+            sb.append(',');
+            sb.append(this.getLat(i));
             if (this.is3D()) {
                 sb.append(',');
                 sb.append(this.getEle(i));

--- a/web-api/src/main/java/com/graphhopper/util/PointList.java
+++ b/web-api/src/main/java/com/graphhopper/util/PointList.java
@@ -17,8 +17,6 @@
  */
 package com.graphhopper.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.graphhopper.util.shapes.GHPoint;
 import com.graphhopper.util.shapes.GHPoint3D;
 import org.locationtech.jts.geom.Coordinate;
@@ -27,7 +25,6 @@ import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -352,16 +349,8 @@ public class PointList implements Iterable<GHPoint3D>, PointAccess {
         return sb.toString();
     }
 
-    public String toGeojsonString(HashMap<String, String> properties) {
+    public String toGeojsonString(String propJsonString) {
         StringBuilder sb = new StringBuilder();
-        ObjectMapper objectMapper = new ObjectMapper();
-        String propJsonString = "{}";
-        try {
-            propJsonString = objectMapper.writeValueAsString(properties);
-        } catch (JsonProcessingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
         sb.append("{\"type\": \"Feature\", \"properties\": "+propJsonString+",\"geometry\": {\"type\": \"LineString\", \"coordinates\": [");
         for (int i = 0; i < size(); i++) {
             if (i > 0)


### PR DESCRIPTION
This PR adds an additional logfile in the `/logs` folder, called `ways_dump.ldgeojson` thats a newline-delimited GeoJson of all the OSM Ways in the graph cache.

This dumpfile can be converted to a visualizable `PMTiles` tileset using 
```
tippecanoe -zg -l ways_dump -P -o out.pmtiles --drop-densest-as-needed ways_dump.ldgeojson
```

I also added a webpage to visualize the data.

<img width="551" alt="image" src="https://github.com/bikehopper/graphhopper/assets/1449257/36f41a30-5de2-4bcc-bc34-a3501e0bc621">

<img width="773" alt="image" src="https://github.com/bikehopper/graphhopper/assets/1449257/58bdac34-5c1b-4191-9616-bff6684edba9">

All the params are in there, here's an example of a OSM Way geo-json-ifield:
```
{
    "type": "Feature",
    "properties": {
        "country": "204",
        "foot_subnetwork": "0",
        "road_access": "0",
        "foot$priority": "0.8",
        "get_off_bike": "0",
        "road_class_link": "1",
        "bike2_subnetwork": "0",
        "foot$access_reversed": "1",
        "id": "4304424",
        "roundabout": "0",
        "bike2$penalty_reversed": "9.0",
        "bike_network": "0",
        "foot_network": "0",
        "bike2$access_reversed": "0",
        "max_speed_reversed": "Infinity",
        "foot$access": "1",
        "road_environment": "4",
        "max_speed": "Infinity",
        "cycleway_reversed": "0",
        "bike2$average_speed_reversed": "18.0",
        "bike2$average_speed": "18.0",
        "smoothness": "0",
        "bike2$access": "1",
        "foot$average_speed": "5.0",
        "grade": "1",
        "name": "",
        "road_class": "4",
        "bike2$penalty": "9.0",
        "cycleway": "0"
    },
    "geometry": {
        "type": "LineString",
        "coordinates": [
            [
                -122.0470346,
                37.3867598,
                28.01300048828125
            ],
            [
                -122.0468441,
                37.3865939,
                28.136999130249023
            ],
            [
                -122.0466566,
                37.3864817,
                28.450000762939453
            ],
            [
                -122.0465405,
                37.3864281,
                28.636999130249023
            ],
            [
                -122.0463011,
                37.386358,
                28.854000091552734
            ]
        ]
    }
}
```

Anything in the `properties` can visualized on the map for debugging.

