### PR TITLE
Fix NullPointerException when not dumping OSM way data

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -116,7 +116,7 @@ public class OSMReader {
                 ldGeojsonWriter = Files.newBufferedWriter(filePath, StandardOpenOption.CREATE);
             }
         } catch (Exception e) {
-            LOGGER.error("Error creating logs/ways_dump.ldgeojson file writer");
+            LOGGER.error("Error creating geojson dumpfile writer");
             e.printStackTrace();
         }
 
@@ -666,11 +666,13 @@ public class OSMReader {
     private void finishedReading() {
         tagParserManager.releaseParsers();
         eleProvider.release();
-        try {
-            ldGeojsonWriter.close();
-        } catch (IOException e) {
-            LOGGER.error("Error closing writer to geojson dumpfile");
-            e.printStackTrace();
+        if (ldGeojsonWriter != null) {
+          try {
+              ldGeojsonWriter.close();
+          } catch (IOException e) {
+              LOGGER.error("Error closing writer to geojson dumpfile");
+              e.printStackTrace();
+          }
         }
         osmWayIdToRelationFlagsMap = null;
         osmWayIdSet = null;


### PR DESCRIPTION
#158 did not fully account for the possibility that the way logging is turned off.

Also, an error has the recommended file path hardcoded in it.