### PR TITLE
Fix 'use_ferries: true'

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -73,6 +73,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     protected BikeCommonFlagEncoder(String name, int speedBits, double speedFactor, int maxTurnCosts,
             boolean speedTwoDirections, boolean useFerries) {
         super(name, speedBits, speedFactor, speedTwoDirections, maxTurnCosts);
+        this.useFerries = useFerries;
 
         penaltyEnc = new DecimalEncodedValueImpl(getKey(name, "penalty"), 4, PenaltyCode.getFactor(1),
                 penaltyTwoDirections);


### PR DESCRIPTION
A bug in PR #85 did not actually initialize the useFerries value, so it defaulted to false, regardless of the config setting. It was impossible to configure the bike router to use ferries, and furthermore, the bike router did not default to using ferries if the setting was omitted from the configuration, as intended.