### PR TITLE
Fix opposite value handling for cycleway:left,right

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMCyclewayParser.java
@@ -19,7 +19,7 @@ public class OSMCyclewayParser implements TagParser {
 
     private final EnumEncodedValue<Cycleway> cyclewayEnc;
     private final Set<String> oneways = new HashSet<>(5);
-    protected final HashMap<String, Cycleway> oppositeLanes = new HashMap<>();
+    protected final HashMap<Cycleway, Cycleway> oppositeLanes = new HashMap<>();
 
     public OSMCyclewayParser() {
         this(new EnumEncodedValue<>(Cycleway.KEY, Cycleway.class, true));
@@ -32,10 +32,10 @@ public class OSMCyclewayParser implements TagParser {
         oneways.add("1");
         oneways.add("-1");
 
-        oppositeLanes.put("opposite", Cycleway.SHARED_LANE);
-        oppositeLanes.put("opposite_lane", Cycleway.LANE);
-        oppositeLanes.put("opposite_track", Cycleway.TRACK);
-        oppositeLanes.put("opposite_share_busway", Cycleway.SHARE_BUSWAY);
+        oppositeLanes.put(Cycleway.OPPOSITE, Cycleway.SHARED_LANE);
+        oppositeLanes.put(Cycleway.OPPOSITE_LANE, Cycleway.LANE);
+        oppositeLanes.put(Cycleway.OPPOSITE_TRACK, Cycleway.TRACK);
+        oppositeLanes.put(Cycleway.OPPOSITE_SHARE_BUSWAY, Cycleway.SHARE_BUSWAY);
     }
 
     @Override
@@ -96,6 +96,11 @@ public class OSMCyclewayParser implements TagParser {
                 cyclewayLeftOnewayTag.equals("") && drivingSide == DrivingSide.RIGHT
                 && !isOnewayForCars
             );
+            // Handle opposite* values for left
+            if (oppositeLanes.containsKey(cyclewayLeft)) {
+              cyclewayLeftBackward = true;
+              cyclewayLeft = oppositeLanes.get(cyclewayLeft);
+            }
             if (cyclewayLeftTwoway || cyclewayLeftBackward)
                 cyclewayBackward = mergeCyclewayValues(cyclewayBackward, cyclewayLeft);
             if (cyclewayLeftTwoway || !cyclewayLeftBackward)
@@ -109,6 +114,11 @@ public class OSMCyclewayParser implements TagParser {
                 cyclewayRightOnewayTag.equals("") && drivingSide == DrivingSide.LEFT
                 && !isOnewayForCars
             );
+            // Handle opposite* values for right
+            if (oppositeLanes.containsKey(cyclewayRight)) {
+              cyclewayRightBackward = true;
+              cyclewayRight = oppositeLanes.get(cyclewayRight);
+            }
             if (cyclewayRightTwoway || cyclewayRightBackward)
                 cyclewayBackward = mergeCyclewayValues(cyclewayBackward, cyclewayRight);
             if (cyclewayRightTwoway || !cyclewayRightBackward)


### PR DESCRIPTION
Although cycleway=opposite* values are [deprecated since 2024](https://wiki.openstreetmap.org/wiki/Tag:cycleway%3Dopposite_track), it's good if we can still handle them. This fixes the handling of a tag combination [seen on Milvia Street in Berkeley](https://www.openstreetmap.org/way/233700520/history/31) at the time of writing:

    cycleway:left=opposite_track
    cycleway:right=track
    oneway=yes
    oneway:bicycle=no

We correctly read the `oneway:bicycle=no` to mark for two-way access, and correctly set the `cyclewayForward` to `TRACK` based on `cycleway:right=track`. But until now, `cycleway:left=opposite_track` was ignored, so `cyclewayBackward` was `MISSING`, making the street look like it had worse infra in that direction than it did.

[Test case](https://bikehopper.org/route/-122.27027,37.87003/to/-122.27377,37.87600). Before, the coloring of the two blocks of Milvia south of University was gray, indicating no bike infrastructure going north:

<img width="968" height="902" alt="Screenshot from 2026-01-22 21-53-53" src="https://github.com/user-attachments/assets/037b60ab-e7e5-45d2-bd06-e726e81bd12f" />

After, those blocks are deep green indicating a protected bike lane:

<img width="968" height="902" alt="Screenshot from 2026-01-22 22-00-42" src="https://github.com/user-attachments/assets/7ded9e09-52b1-4fd7-a7a8-c46d6261d993" />

It also looks like the handling of opposite values in general (written by me in 2023) might have been broken because `oppositeLanes` was a map from String to Cycleway, but its `containsKey` was being called with a Cycleway rather than String value. (I don't understand why this isn't a type error at compile time.)

Fixes #172